### PR TITLE
Capture uploader IP and surface stream link on landing page

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -29,6 +29,20 @@
         box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
         max-width: 60rem;
       }
+      .device-card {
+        margin-top: 1.5rem;
+        border-left: 4px solid #2563eb;
+      }
+      .device-card h2 {
+        margin-top: 0;
+      }
+      .device-card a {
+        color: #2563eb;
+        text-decoration: none;
+      }
+      .device-card a:hover {
+        text-decoration: underline;
+      }
     </style>
   </head>
   <body>
@@ -51,5 +65,21 @@
         <li>當新的臉孔被辨識後，廣告頁會自動刷新。</li>
       </ol>
     </div>
+    {% if last_uploader_ip %}
+    <div class="card device-card">
+      <h2>最近上傳的裝置</h2>
+      <p>
+        IP 位址：<code>{{ last_uploader_ip }}</code>
+      </p>
+      {% if camera_stream_url %}
+      <p>
+        即時影像：
+        <a href="{{ camera_stream_url }}" target="_blank" rel="noopener"
+          >{{ camera_stream_url }}</a
+        >
+      </p>
+      {% endif %}
+    </div>
+    {% endif %}
   </body>
 </html>

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,0 +1,39 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend import app as app_module
+
+
+def test_upload_face_records_last_ip(tmp_path, monkeypatch):
+    test_db_path = tmp_path / "test.sqlite3"
+    test_database = app_module.Database(test_db_path)
+    test_database.ensure_demo_data()
+    monkeypatch.setattr(app_module, "database", test_database)
+
+    app_module.last_uploader_ip = None
+
+    client = app_module.app.test_client()
+    headers = {"X-Forwarded-For": "203.0.113.42"}
+    response = client.post(
+        "/upload_face",
+        data=b"test-bytes",
+        content_type="image/jpeg",
+        headers=headers,
+    )
+
+    assert response.status_code in (200, 201)
+    payload = json.loads(response.get_data(as_text=True))
+    assert payload["status"] == "ok"
+
+    assert app_module.last_uploader_ip == "203.0.113.42"
+
+    landing_page = client.get("/")
+    assert landing_page.status_code == 200
+    body = landing_page.get_data(as_text=True)
+    assert "203.0.113.42" in body
+    assert "http://203.0.113.42:81/stream" in body


### PR DESCRIPTION
## Summary
- capture the ESP32-CAM uploader IP during face uploads and surface the derived stream URL to templates
- show the last seen device IP and clickable stream link on the landing page when available
- add a regression test that posts an upload and verifies the landing page exposes the ESP32 address

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16224f8f48322b5638d09ba6efc7f