### PR TITLE
Seed demo member data from local pictures

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,80 @@
+name: Verify project files
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  file-hygiene:
+    name: Validate tracked files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run repository validation
+        run: python scripts/validate_files.py
+
+  backend:
+    name: Backend checks
+    runs-on: ubuntu-latest
+    needs: file-hygiene
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Compile Python sources
+        run: python -m compileall .
+
+  firmware:
+    name: Firmware build
+    runs-on: ubuntu-latest
+    needs: file-hygiene
+    defaults:
+      run:
+        working-directory: firmware/esp32cam_mvp
+    env:
+      PLATFORMIO_SETTING_ENABLE_TELEMETRY: "false"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-platformio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-platformio-
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+
+      - name: Build firmware
+        run: pio run

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
    - `GET /ad/<member_id>`：根據 SQLite + Gemini Text 的輸出生成廣告頁，內建 `<meta http-equiv="refresh" content="5">`，適合放在電視棒上自動輪播。
    - `GET /health`：基本健康檢查。
 
-5. SQLite 會自動建立資料庫與 Demo 資料。辨識到新臉孔時，系統會以 Gemini Vision 摘要雜湊生成匿名 `MEMxxxxxxxxxx` 並寫入歡迎禮優惠。
+5. SQLite 會自動建立資料庫與 Demo 資料。啟動時會讀取 `backend/demo_members.json`，
+   由 `pictures/` 內的示範照片產生會員編號與歷史消費紀錄（例如 `face6.jpg`
+   對應 `MEM1B5ADE459D`），便於直接開啟 `/ad/<member_id>` 頁面體驗流程。辨識到
+   新臉孔時，系統會以 Gemini Vision 摘要雜湊生成匿名 `MEMxxxxxxxxxx` 並寫入歡迎禮
+   優惠。
 
 6. 手動測試（使用任何 JPEG）：
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -25,7 +25,7 @@ app.config["JSON_AS_ASCII"] = False
 gemini = GeminiService()
 recognizer = FaceRecognizer(gemini)
 database = Database(DB_PATH)
-database.ensure_demo_data()
+database.ensure_demo_data(recognizer)
 
 
 @app.get("/")

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import mimetypes
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from .recognizer import FaceEncoding, FaceRecognizer
 
 _LOGGER = logging.getLogger(__name__)
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEMO_DATA_PATH = Path(__file__).resolve().parent / "demo_members.json"
 
 
 @dataclass
@@ -134,26 +138,48 @@ class Database:
         ]
 
     # ------------------------------------------------------------------
-    def ensure_demo_data(self) -> None:
+    def ensure_demo_data(self, recognizer: FaceRecognizer | None = None) -> None:
         """Populate the database with a few demo purchases if empty."""
 
         with self._connect() as conn:
             has_members = conn.execute("SELECT COUNT(*) FROM members").fetchone()[0] > 0
-            has_purchases = conn.execute("SELECT COUNT(*) FROM purchases").fetchone()[0] > 0
+            has_purchases = (
+                conn.execute("SELECT COUNT(*) FROM purchases").fetchone()[0] > 0
+            )
 
-        if has_members and has_purchases:
+        dataset = self._load_demo_dataset()
+        if dataset:
+            if not has_members:
+                for entry in dataset:
+                    member_id = entry["member_id"]
+                    encoding = self._encoding_from_demo(entry, recognizer)
+                    if encoding is None:
+                        encoding = self._fallback_encoding(member_id)
+                    self.create_member(encoding, member_id=member_id)
+
+            if not has_purchases:
+                for entry in dataset:
+                    for purchase in entry.get("purchases", []):
+                        try:
+                            discount = float(purchase.get("discount", 0.0))
+                        except (TypeError, ValueError):
+                            discount = 0.0
+                        self.add_purchase(
+                            entry["member_id"],
+                            str(purchase.get("item", "")) or "人氣商品",
+                            str(purchase.get("last_purchase", "2024-01-01")),
+                            discount,
+                            str(purchase.get("recommendation", "歡迎再次光臨！")),
+                        )
+                if dataset:
+                    _LOGGER.info(
+                        "Seeded demo dataset with %d member(s)",
+                        len(dataset),
+                    )
             return
 
         if not has_members:
-            # Create a synthetic member using a deterministic encoding so it works both
-            # with real and hash based recognition.
-            import numpy as np
-
-            encoding = FaceEncoding(
-                np.zeros(128, dtype=np.float32),
-                signature="demo-member",
-                source="seed",
-            )
+            encoding = self._fallback_encoding("MEMDEMO001")
             demo_member = self.create_member(encoding, member_id="MEMDEMO001")
         else:
             with self._connect() as conn:
@@ -177,4 +203,81 @@ class Database:
                 "早餐搭配現磨咖啡可享第二杯半價。",
             )
             _LOGGER.info("Seeded demo purchase history for %s", demo_member)
+
+    # ------------------------------------------------------------------
+    def _load_demo_dataset(self) -> list[dict[str, Any]]:
+        if not DEMO_DATA_PATH.exists():
+            return []
+
+        try:
+            with DEMO_DATA_PATH.open("r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            _LOGGER.warning("Unable to read demo dataset: %s", exc)
+            return []
+
+        if not isinstance(payload, list):
+            _LOGGER.warning("Demo dataset must be a list of entries")
+            return []
+
+        entries: list[dict[str, Any]] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            member_id = str(item.get("member_id", "")).strip()
+            if not member_id:
+                continue
+            entry: dict[str, Any] = {
+                "member_id": member_id,
+                "image": item.get("image"),
+                "purchases": item.get("purchases", []),
+            }
+            entries.append(entry)
+        return entries
+
+    def _encoding_from_demo(
+        self, entry: dict[str, Any], recognizer: FaceRecognizer | None
+    ) -> FaceEncoding | None:
+        if recognizer is None:
+            return None
+
+        image_ref = entry.get("image")
+        if not image_ref:
+            return None
+
+        image_path = Path(str(image_ref))
+        if not image_path.is_absolute():
+            candidate = PROJECT_ROOT / image_path
+            if candidate.exists():
+                image_path = candidate
+            else:
+                image_path = PROJECT_ROOT / "pictures" / image_path.name
+
+        if not image_path.exists():
+            _LOGGER.warning("Demo image not found: %s", image_path)
+            return None
+
+        try:
+            image_bytes = image_path.read_bytes()
+        except OSError as exc:
+            _LOGGER.warning("Unable to read demo image %s: %s", image_path, exc)
+            return None
+
+        mime_type = mimetypes.guess_type(str(image_path))[0] or "image/jpeg"
+        try:
+            return recognizer.encode(image_bytes, mime_type=mime_type)
+        except ValueError as exc:
+            _LOGGER.warning("Unable to encode demo image %s: %s", image_path, exc)
+            return None
+
+    @staticmethod
+    def _fallback_encoding(member_id: str) -> FaceEncoding:
+        import numpy as np
+
+        signature = f"demo-{member_id}"
+        return FaceEncoding(
+            np.zeros(128, dtype=np.float32),
+            signature=signature,
+            source="seed",
+        )
 

--- a/backend/demo_members.json
+++ b/backend/demo_members.json
@@ -1,0 +1,20 @@
+[
+  {
+    "member_id": "MEM1B5ADE459D",
+    "image": "pictures/face6.jpg",
+    "purchases": [
+      {
+        "item": "精品濾掛咖啡",
+        "last_purchase": "2024-01-12",
+        "discount": 0.25,
+        "recommendation": "今日搭配手工可頌再享 85 折，限時優惠！"
+      },
+      {
+        "item": "手工磅蛋糕",
+        "last_purchase": "2023-12-08",
+        "discount": 0.1,
+        "recommendation": "甜點任選第二件半價，咖啡一起帶走最划算。"
+      }
+    ]
+  }
+]

--- a/scripts/validate_files.py
+++ b/scripts/validate_files.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Repository-wide validation helpers.
+
+The GitHub Actions workflow uses this script to ensure that every tracked
+text file respects some basic hygiene rules before code is merged.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Iterable, List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def run_git_ls_files() -> List[Path]:
+    """Return all files tracked by git as absolute paths."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return [REPO_ROOT / Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+
+
+def is_text_file(path: Path, sample_size: int = 4096) -> bool:
+    """Heuristically determine whether *path* is a UTF-8 text file."""
+    try:
+        with path.open("rb") as fp:
+            sample = fp.read(sample_size)
+    except OSError:
+        return False
+
+    if b"\x00" in sample:
+        return False
+
+    if not sample:
+        return True
+
+    try:
+        sample.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+
+    return True
+
+
+def validate_text_file(path: Path, errors: List[str]) -> None:
+    """Validate newline and trailing whitespace for *path*."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        errors.append(f"{path.relative_to(REPO_ROOT)}: not valid UTF-8 text")
+        return
+
+    if content and not content.endswith("\n"):
+        errors.append(f"{path.relative_to(REPO_ROOT)}: missing trailing newline")
+
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        if line.rstrip() != line:
+            errors.append(
+                f"{path.relative_to(REPO_ROOT)}:{line_number}: trailing whitespace"
+            )
+
+
+def main() -> int:
+    errors: List[str] = []
+    files: Iterable[Path] = run_git_ls_files()
+
+    for path in files:
+        if not path.exists() or path.is_dir():
+            errors.append(f"{path.relative_to(REPO_ROOT)}: missing from filesystem")
+            continue
+
+        if not is_text_file(path):
+            continue
+
+        validate_text_file(path, errors)
+
+    if errors:
+        print("Repository validation failed:\n")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("All tracked text files passed validation.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- load demo members and purchases from `backend/demo_members.json`, encoding demo faces via the configured recognizer when the database is empty
- ensure the Flask app passes its recognizer instance to demo seeding and document the new dataset workflow
- add a demo record for `pictures/face6.jpg` so `/ad/MEM1B5ADE459D` immediately renders an advertising page without hard-coded logic

## Testing
- python scripts/validate_files.py
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d1f6cae490832890234abf52fb6ead