### PR TITLE
feat: use face list find-similar for visitor reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # ESP32-CAM Retail Advertising MVP
 
-新版 MVP 聚焦在「ESP32-CAM 拍照 → 雲端 Flask 後端 → Gemini Vision + Gemini Text → SQLite → HDMI 看板」的最小可執行流程。攝影機即時上傳照片，後端呼叫 Gemini Vision 取得臉部特徵摘要並產生匿名會員 ID，透過 SQLite 撈取歷史消費資料，再用 Gemini Text 自動生成個人化廣告文案，最後輸出給電視棒（HDMI Dongle）輪播。若未啟用 Gemini，系統仍會以雜湊比對與預設模板提供完整端到端流程。
+新版 MVP 聚焦在「ESP32-CAM 拍照 → 雲端 Flask 後端 → Azure Face API → SQLite → HDMI 看板」的最小可執行流程。攝影機即時上傳照片，後端呼叫 Azure Face 取得臉部特徵摘要並產生匿名會員 ID，透過 SQLite 撈取歷史消費資料，再以簡易模板輸出客製化廣告文案。若未啟用 Azure Face，系統仍會以雜湊比對與預設模板提供完整端到端流程。
 
 ## 系統架構與技術流程
 
 1. **ESP32-CAM 拍照上傳**：韌體每隔數秒拍照並透過 HTTP POST 將 JPEG 送至雲端 `/upload_face` API。
-2. **Gemini Vision 雲端辨識**：Flask 後端把影像送進 Gemini Vision，取得描述臉部特徵的文字摘要，將其雜湊後生成匿名 `MEMxxxxxxxxxx` 會員 ID。
+2. **Azure Face 雲端辨識**：Flask 後端把影像送進 Azure Face API，取得臉部特徵摘要後會先透過 Find Similar API 與我們維護的 Face List 做比對；若命中，就直接重用既有會員 ID。若未找到或帳戶已獲得 Person Group 權限，系統也會同步更新 Person Group，讓後續還是能沿用 Azure 的 Person ID。
 3. **SQLite 會員 & 消費資料**：後端使用摘要向 SQLite 查詢既有會員與歷史訂單，找不到則建立新會員並寫入歡迎優惠。
-4. **Gemini Text 生成廣告**：把會員歷史紀錄整理成 JSON，交給 Gemini Text 回傳包含主標、副標、促購亮點的廣告文案。
+4. **模板產生廣告**：把會員歷史紀錄整理成 JSON，套用內建模板產出主標、副標、促購亮點的廣告文案，確保即使未啟用雲端 AI 也能維持完整流程。
 5. **廣告頁輸出**：後端將文案與歷史訂單傳入 Jinja2 模板 `/ad/<member_id>`，網頁每 5 秒自動刷新，適合放在 HDMI 電視棒或任何瀏覽器輪播。
 
 ## 專案結構
 
 ```
-backend/                # Flask 後端：API、Gemini 介接、SQLite、廣告模板
-  ai.py                 # Gemini Vision / Text 封裝與錯誤處理
+backend/                # Flask 後端：API、Azure Face 介接、SQLite、廣告模板
+  ai.py                 # Azure Face 封裝與錯誤處理（含廣告模板）
   app.py                # 主要進入點（/upload_face、/ad/<id> 等）
   database.py           # SQLite 存取與 Demo 資料建立
-  recognizer.py         # 使用 Gemini 產生匿名特徵，含 hash fallback
+  recognizer.py         # 使用 Azure Face 產生匿名特徵，含 hash fallback
   advertising.py        # 根據消費紀錄與 AI 文案產出頁面所需內容
   templates/            # Jinja2 模板（首頁 + 廣告頁，含自動刷新）
 firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
@@ -26,7 +26,7 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
   platformio.ini        # PlatformIO 組態（Arduino framework）
 ```
 
-## 後端（Flask + SQLite + Gemini）
+## 後端（Flask + SQLite + Azure Face）
 
 1. 建議使用虛擬環境安裝依賴：
 
@@ -39,15 +39,23 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
    cd ..  # 回到專案根目錄
    ```
 
-   `requirements.txt` 內包含 `google-generativeai`。若無法存取網路或暫時沒有 API Key，Gemini 功能會自動停用並退回到純雜湊比對與固定模板。
+   `requirements.txt` 內包含最新版的 `azure-ai-vision-face` SDK。若暫時沒有金鑰，後端會自動退回到純雜湊比對與固定模板。
 
-2. 設定 Gemini API Key：
+2. 設定 Azure Face 認證：
 
    ```bash
-   export GEMINI_API_KEY="<your_api_key>"
+   export AZURE_FACE_ENDPOINT="https://<your-resource>.cognitiveservices.azure.com/"
+   export AZURE_FACE_KEY="<your_face_api_key>"
+   export AZURE_FACE_PERSON_GROUP_ID="esp32cam-mvp"    # 可自訂，會自動建立（選填）
+   export AZURE_FACE_LIST_ID="esp32cam-mvp-faces"      # Find Similar 使用的 Face List（可省略使用預設值）
    ```
 
-   未設定時後端仍可運作，但不會呼叫 Gemini。部署到雲端（例如 Cloud Run）時，也可改放在環境變數或 Secret Manager。
+   未設定時後端仍可運作，但只會使用雜湊簽名與預設廣告模板。部署到雲端（例如 Cloud Run）時，也可改放在環境變數或 Secret Manager。
+
+   > ⚠️ **Person Group 權限申請**：Azure Face 的 Person Group / Identify API 需額外核准
+   > 「Identification/Verification」功能才能啟用。若帳號尚未被核准，後端會自動停用
+   > 相關功能並僅保留臉部描述與 Face List 比對；頁面會提示前往
+   > <https://aka.ms/facerecognition> 申請預覽權限。
 
 3. 啟動 Flask 伺服器（於專案根目錄執行）：
 
@@ -58,10 +66,11 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
 4. API 重點：
 
    - `POST /upload_face`：接受 `image/jpeg` 或 `multipart/form-data` 影像。回傳 JSON，內含 `member_id`、`new_member` 旗標與廣告頁 URL。
-   - `GET /ad/<member_id>`：根據 SQLite + Gemini Text 的輸出生成廣告頁，內建 `<meta http-equiv="refresh" content="5">`，適合放在電視棒上自動輪播。
+   - `GET /ad/<member_id>`：根據 SQLite + 模板化文案輸出生成廣告頁，內建 `<meta http-equiv="refresh" content="5">`，適合放在電視棒上自動輪播。
    - `GET /health`：基本健康檢查。
+   - `GET /person-group`：提供瀏覽器表單，可輸入會員 ID 並上傳多張臉部照片，預先將該會員訓練至 Azure Face Person Group。
 
-5. SQLite 會自動建立資料庫與 Demo 資料。辨識到新臉孔時，系統會以 Gemini Vision 摘要雜湊生成匿名 `MEMxxxxxxxxxx` 並寫入歡迎禮優惠。
+5. SQLite 會自動建立資料庫與 Demo 資料。辨識到新臉孔時，系統會以 Azure Face 摘要雜湊生成匿名 `MEMxxxxxxxxxx` 並寫入歡迎禮優惠，同時把臉部向量註冊到 Azure Face List（及可用時的 Person Group），以便下一次造訪可直接透過 Find Similar 命中既有會員。
 
 6. 手動測試（使用任何 JPEG）：
 
@@ -83,10 +92,16 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
    }
    ```
 
+7. 需要先在 Person Group / Face List 中訓練特定顧客時，可開啟瀏覽器造訪 `http://localhost:8000/person-group`：
+
+   - 輸入既有或預期的會員 ID（例如從 CRM 匯出的代碼）。
+   - 一次選擇多張臉部照片並提交，系統會在 Azure 中建立/更新 Person，並同步把 Face List 與（可用時）Person ID 存回 SQLite。
+   - 若該會員在資料庫中不存在，後端會自動建立一筆基礎會員資料，方便後續比對。
+
 ## 前端展示（電視棒 / 螢幕）
 
 - 在電視棒或任何瀏覽器打開 `http://<server-ip>:8000/ad/<member_id>` 即可。
-- 網頁每 5 秒刷新一次，Gemini Text 產出的主標、副標、促購亮點會即時更新。若 AI 功能未啟用，則會顯示預設模板。
+- 網頁每 5 秒刷新一次，若啟用 Azure Face 會根據臉部描述帶入專屬文案；未啟用時則顯示預設模板。
 
 ## ESP32-CAM（PlatformIO 範例）
 
@@ -111,15 +126,15 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
 
 ## Demo 建議流程
 
-1. 啟動雲端或本地的 Flask 伺服器並設定 `GEMINI_API_KEY`。
+1. 啟動雲端或本地的 Flask 伺服器並設定 `AZURE_FACE_ENDPOINT` / `AZURE_FACE_KEY`。
 2. 將 HDMI 電視棒固定在 `/ad/<member_id>` 頁面，或使用瀏覽器展示。
-3. ESP32-CAM 開機 → 拍照上傳 → 後端呼叫 Gemini Vision → 查詢 SQLite → Gemini Text 生成廣告 → 頁面自動刷新，整體流程預期 < 10 秒。
+3. ESP32-CAM 開機 → 拍照上傳 → 後端呼叫 Azure Face → 查詢 SQLite → 套用模板生成廣告 → 頁面自動刷新，整體流程預期 < 10 秒。
 4. 錄製 < 1 分鐘 Demo 影片展示「上傳 → 廣告更新」的完整閉環。
 
 ## 後續擴充想法（Nice-to-Have）
 
 - 可接軌 YOLO 行為追蹤、多人排隊分析，或串接雲端資料倉儲。
 - 替換 SQLite 為雲端資料庫（Cloud SQL / Firestore），並把 Flask 佈署到 Cloud Run、App Engine 或 Kubernetes。
-- 擴充 Gemini 提示，讓 AI 文案依照天氣、時段或會員屬性動態調整促銷內容。
+- 若需更智慧的文案，可再串接語言模型或其他雲端 AI 服務，依天氣、時段或會員屬性動態調整促銷內容。
 
 祝開發順利！

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,9 +9,9 @@ from typing import Tuple
 from flask import Flask, jsonify, render_template, request, url_for
 
 from .advertising import build_ad_context
-from .ai import GeminiService, GeminiUnavailableError
+from .ai import AzureFaceError, AzureFaceService
 from .database import Database
-from .recognizer import FaceRecognizer
+from .recognizer import FaceEncoding, FaceRecognizer
 
 logging.basicConfig(level=logging.INFO)
 
@@ -22,8 +22,8 @@ DB_PATH = DATA_DIR / "mvp.sqlite3"
 app = Flask(__name__, template_folder=str(BASE_DIR / "templates"))
 app.config["JSON_AS_ASCII"] = False
 
-gemini = GeminiService()
-recognizer = FaceRecognizer(gemini)
+face_service = AzureFaceService()
+recognizer = FaceRecognizer(face_service)
 database = Database(DB_PATH)
 database.ensure_demo_data()
 
@@ -31,6 +31,170 @@ database.ensure_demo_data()
 @app.get("/")
 def index() -> str:
     return render_template("index.html")
+
+
+@app.route("/person-group", methods=["GET", "POST"])
+def person_group_trainer():
+    """Render a simple UI to upload faces for Azure Person Group training."""
+
+    context = {
+        "azure_enabled": face_service.can_manage_person_group,
+        "azure_configured": face_service.can_describe_faces,
+        "azure_person_group_error": getattr(face_service, "person_group_error", None),
+        "member_id": "",
+        "results": [],
+        "errors": [],
+        "azure_person_id": None,
+        "faces_registered": 0,
+        "created_member": False,
+    }
+
+    if request.method == "POST":
+        member_id = (request.form.get("member_id") or "").strip()
+        context["member_id"] = member_id
+
+        if not member_id:
+            context["errors"].append("請輸入會員 ID。")
+
+        uploads = []
+        if request.files:
+            for field in ("images", "image", "files", "photos"):
+                for storage in request.files.getlist(field):
+                    data = storage.read()
+                    if not data:
+                        continue
+                    uploads.append(
+                        {
+                            "name": storage.filename,
+                            "bytes": data,
+                            "mimetype": storage.mimetype or request.mimetype or "image/jpeg",
+                        }
+                    )
+        if not uploads:
+            context["errors"].append("請選擇至少一張要上傳的照片。")
+
+        if not face_service.can_manage_person_group:
+            if face_service.person_group_error:
+                context["errors"].append(face_service.person_group_error)
+            else:
+                context["errors"].append(
+                    "Azure Face Person Group 功能未啟用，請設定 AZURE_FACE_ENDPOINT / AZURE_FACE_KEY。"
+                )
+
+        azure_person_id: str | None = None
+        existing_encoding: FaceEncoding | None = None
+        created_person = False
+        persisted_face_ids: list[str] = []
+
+        if not context["errors"]:
+            existing_encoding = database.get_member_encoding(member_id)
+            if existing_encoding:
+                azure_person_id = existing_encoding.azure_person_id
+                if not existing_encoding.azure_person_name:
+                    existing_encoding.azure_person_name = member_id
+
+            if azure_person_id is None:
+                try:
+                    azure_person_id = face_service.find_person_id_by_name(member_id)
+                except AzureFaceError as exc:
+                    context["errors"].append(f"查詢 Azure Person 失敗：{exc}")
+
+        encoding: FaceEncoding | None = existing_encoding
+
+        if not context["errors"] and encoding is None and uploads:
+            primary_upload = uploads[0]
+            try:
+                encoding = recognizer.encode(primary_upload["bytes"], mime_type=primary_upload["mimetype"])
+            except ValueError as exc:
+                context["errors"].append(f"無法產生臉部特徵：{exc}")
+
+        start_index = 0
+        if not context["errors"] and uploads:
+            primary_upload = uploads[0]
+            if azure_person_id is None:
+                try:
+                    azure_person_id = face_service.register_person(
+                        member_id,
+                        primary_upload["bytes"],
+                        user_data=member_id,
+                    )
+                except AzureFaceError as exc:
+                    context["errors"].append(f"建立 Azure Person 失敗：{exc}")
+                else:
+                    context["faces_registered"] += 1
+                    context["results"].append(primary_upload["name"] or "face-1.jpg")
+                    start_index = 1
+                    created_person = True
+                    if encoding is None:
+                        vector = FaceRecognizer._vector_from_signature(azure_person_id)
+                        encoding = FaceEncoding(
+                            vector=vector,
+                            face_description=member_id,
+                            source="azure-person-group",
+                        )
+                if face_service.can_use_face_list:
+                    try:
+                        persisted_id = face_service.add_face_to_face_list(
+                            member_id,
+                            primary_upload["bytes"],
+                            user_data=member_id,
+                        )
+                    except AzureFaceError as exc:
+                        context["errors"].append(f"{primary_upload['name'] or 'face-1.jpg'} 加入 Face List 失敗：{exc}")
+                    else:
+                        persisted_face_ids.append(persisted_id)
+
+            if azure_person_id:
+                for upload in uploads[start_index:]:
+                    try:
+                        face_service.add_face_to_person(azure_person_id, upload["bytes"])
+                    except AzureFaceError as exc:
+                        context["errors"].append(
+                            f"{upload['name'] or '照片'} 加入 Person Group 時失敗：{exc}"
+                        )
+                    else:
+                        context["faces_registered"] += 1
+                        context["results"].append(upload["name"] or "face.jpg")
+                    if face_service.can_use_face_list:
+                        try:
+                            persisted_id = face_service.add_face_to_face_list(
+                                member_id,
+                                upload["bytes"],
+                                user_data=member_id,
+                            )
+                        except AzureFaceError as exc:
+                            context["errors"].append(
+                                f"{upload['name'] or '照片'} 加入 Face List 時失敗：{exc}"
+                            )
+                        else:
+                            persisted_face_ids.append(persisted_id)
+
+                if encoding is not None:
+                    encoding.azure_person_id = azure_person_id
+                    encoding.azure_person_name = member_id
+                    if not encoding.face_description:
+                        encoding.face_description = member_id
+                    encoding.source = "azure-person-group"
+                    if persisted_face_ids:
+                        encoding.azure_persisted_face_id = encoding.azure_persisted_face_id or persisted_face_ids[0]
+                        if encoding.source != "azure-person-group":
+                            encoding.source = "azure-face-list"
+                    if existing_encoding is None:
+                        database.create_member(encoding, member_id=member_id)
+                        context["created_member"] = True
+                    else:
+                        database.update_member_encoding(member_id, encoding)
+
+                additional_faces = context["faces_registered"] - (1 if created_person else 0)
+                if additional_faces > 0:
+                    try:
+                        face_service.train_person_group(suppress_errors=False)
+                    except AzureFaceError as exc:
+                        context["errors"].append(f"訓練 Person Group 失敗：{exc}")
+
+        context["azure_person_id"] = azure_person_id
+
+    return render_template("person_group.html", context=context)
 
 
 @app.post("/upload_face")
@@ -47,12 +211,161 @@ def upload_face():
     except ValueError as exc:
         return jsonify({"status": "error", "message": str(exc)}), 422
 
-    member_id, distance = database.find_member_by_encoding(encoding, recognizer)
+    member_id: str | None = None
+    distance: float | None = None
+    persisted_face_id: str | None = None
+
+    if encoding.azure_person_name:
+        stored_encoding = database.get_member_encoding(encoding.azure_person_name)
+        if stored_encoding is not None:
+            member_id = encoding.azure_person_name
+            distance = 0.0
+
+    if (
+        member_id is None
+        and face_service.can_use_face_list
+        and encoding.azure_face_id
+    ):
+        try:
+            matches = face_service.find_similar_faces(
+                encoding.azure_face_id,
+                max_candidates=3,
+            )
+        except AzureFaceError as exc:
+            logging.warning("Azure Face findSimilar unavailable: %s", exc)
+        else:
+            for match in matches:
+                persisted = match.get("persisted_face_id")
+                if not isinstance(persisted, str) or not persisted:
+                    continue
+                matched_member, stored_encoding = database.find_member_by_persisted_face_id(
+                    persisted
+                )
+                if matched_member:
+                    member_id = matched_member
+                    distance = 0.0
+                    persisted_face_id = persisted
+                    confidence = match.get("confidence")
+                    try:
+                        encoding.azure_confidence = float(confidence) if confidence is not None else None
+                    except (TypeError, ValueError):
+                        encoding.azure_confidence = None
+                    encoding.azure_persisted_face_id = persisted
+                    if encoding.source != "azure-person-group":
+                        encoding.source = "azure-face-list"
+                    if stored_encoding is not None:
+                        updated = False
+                        if stored_encoding.azure_persisted_face_id != persisted:
+                            stored_encoding.azure_persisted_face_id = persisted
+                            updated = True
+                        if (
+                            encoding.azure_confidence is not None
+                            and stored_encoding.azure_confidence != encoding.azure_confidence
+                        ):
+                            stored_encoding.azure_confidence = encoding.azure_confidence
+                            updated = True
+                        if (
+                            encoding.face_description
+                            and not stored_encoding.face_description
+                        ):
+                            stored_encoding.face_description = encoding.face_description
+                            updated = True
+                        if (
+                            encoding.source != "hash"
+                            and stored_encoding.source != encoding.source
+                        ):
+                            stored_encoding.source = encoding.source
+                            updated = True
+                        if updated:
+                            database.update_member_encoding(matched_member, stored_encoding)
+                    break
+
+    if member_id is None:
+        member_id, distance = database.find_member_by_encoding(encoding, recognizer)
+
     new_member = False
     if member_id is None:
-        member_id = database.create_member(encoding, recognizer.derive_member_id(encoding))
+        member_seed = recognizer.derive_member_id(encoding)
+        if face_service.can_manage_person_group:
+            try:
+                azure_person_id = face_service.register_person(member_seed, image_bytes)
+                encoding.azure_person_id = azure_person_id
+                encoding.azure_person_name = member_seed
+                encoding.source = "azure-person-group"
+            except AzureFaceError as exc:
+                logging.warning("Azure Face registration unavailable: %s", exc)
+        if face_service.can_use_face_list:
+            try:
+                persisted_face_id = face_service.add_face_to_face_list(
+                    member_seed,
+                    image_bytes,
+                    user_data=member_seed,
+                )
+            except AzureFaceError as exc:
+                logging.warning("Azure Face face list unavailable: %s", exc)
+            else:
+                encoding.azure_persisted_face_id = persisted_face_id
+                if encoding.source != "azure-person-group":
+                    encoding.source = "azure-face-list"
+        member_id = database.create_member(encoding, member_seed)
         _create_welcome_purchase(member_id)
         new_member = True
+    else:
+        # Update stored metadata if Azure supplied additional information.
+        stored_encoding = database.get_member_encoding(member_id)
+        if stored_encoding is not None:
+            changed = False
+            if encoding.azure_person_id and stored_encoding.azure_person_id != encoding.azure_person_id:
+                stored_encoding.azure_person_id = encoding.azure_person_id
+                changed = True
+            if encoding.azure_person_name and stored_encoding.azure_person_name != encoding.azure_person_name:
+                stored_encoding.azure_person_name = encoding.azure_person_name
+                changed = True
+            elif encoding.azure_person_id and not stored_encoding.azure_person_name:
+                stored_encoding.azure_person_name = member_id
+                changed = True
+            if (
+                persisted_face_id
+                and stored_encoding.azure_persisted_face_id != persisted_face_id
+            ):
+                stored_encoding.azure_persisted_face_id = persisted_face_id
+                changed = True
+            if encoding.azure_confidence is not None:
+                stored_encoding.azure_confidence = encoding.azure_confidence
+                changed = True
+            if encoding.face_description and not stored_encoding.face_description:
+                stored_encoding.face_description = encoding.face_description
+                changed = True
+            if encoding.source != "hash" and stored_encoding.source != encoding.source:
+                stored_encoding.source = encoding.source
+                changed = True
+            if changed:
+                database.update_member_encoding(member_id, stored_encoding)
+        if encoding.azure_person_id and not encoding.azure_person_name:
+            encoding.azure_person_name = member_id
+        if (
+            persisted_face_id is None
+            and face_service.can_use_face_list
+            and not encoding.azure_persisted_face_id
+        ):
+            try:
+                persisted_face_id = face_service.add_face_to_face_list(
+                    member_id,
+                    image_bytes,
+                    user_data=member_id,
+                )
+            except AzureFaceError as exc:
+                logging.warning("Azure Face face list unavailable: %s", exc)
+            else:
+                encoding.azure_persisted_face_id = persisted_face_id
+                if encoding.source != "azure-person-group":
+                    encoding.source = "azure-face-list"
+                stored_encoding = database.get_member_encoding(member_id)
+                if stored_encoding is not None:
+                    stored_encoding.azure_persisted_face_id = persisted_face_id
+                    if stored_encoding.source == "hash":
+                        stored_encoding.source = encoding.source
+                    database.update_member_encoding(member_id, stored_encoding)
 
     payload = {
         "status": "ok",
@@ -69,9 +382,9 @@ def upload_face():
 def render_ad(member_id: str):
     purchases = database.get_purchase_history(member_id)
     creative = None
-    if gemini.can_generate_ads:
+    if face_service.can_generate_ads:
         try:
-            creative = gemini.generate_ad_copy(
+            creative = face_service.generate_ad_copy(
                 member_id,
                 [
                     {
@@ -83,8 +396,8 @@ def render_ad(member_id: str):
                     for purchase in purchases
                 ],
             )
-        except GeminiUnavailableError as exc:
-            logging.warning("Gemini ad generation unavailable: %s", exc)
+        except AzureFaceError as exc:
+            logging.warning("Azure Face ad generation unavailable: %s", exc)
     context = build_ad_context(member_id, purchases, creative=creative)
     return render_template("ad.html", context=context)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
 Flask>=2.3
 numpy>=1.24
 Pillow>=9.5
-google-generativeai>=0.5.0
+azure-ai-vision-face

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -43,6 +43,10 @@
           <code>GET /ad/&lt;member_id&gt;</code>：根據會員資料產生即時廣告頁面。
         </li>
         <li><code>GET /health</code>：服務健康檢查。</li>
+        <li>
+          <code>GET /person-group</code>：開啟瀏覽器上傳同一位顧客的多張照片，預先訓練 Azure Face
+          Person Group。
+        </li>
       </ul>
       <p>建議工作流程：</p>
       <ol>

--- a/backend/templates/person_group.html
+++ b/backend/templates/person_group.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <title>Azure Person Group 訓練工具</title>
+    <style>
+      body {
+        font-family: "Noto Sans TC", "PingFang TC", sans-serif;
+        margin: 0;
+        padding: 2rem;
+        background: #f3f4f6;
+        color: #111827;
+      }
+      a {
+        color: #2563eb;
+      }
+      h1 {
+        margin-top: 0;
+        font-size: 2.2rem;
+      }
+      .card {
+        background: #ffffff;
+        border-radius: 1rem;
+        padding: 2.5rem;
+        box-shadow: 0 15px 30px rgba(15, 23, 42, 0.12);
+        max-width: 720px;
+      }
+      .form-group {
+        margin-bottom: 1.5rem;
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+      input[type="text"] {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border-radius: 0.75rem;
+        border: 1px solid #d1d5db;
+        font-size: 1rem;
+      }
+      input[type="file"] {
+        padding: 0.5rem 0;
+      }
+      button {
+        background: linear-gradient(135deg, #2563eb, #4f46e5);
+        color: #ffffff;
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1.75rem;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+      button:hover {
+        opacity: 0.95;
+      }
+      .notice {
+        background: #eef2ff;
+        border-radius: 0.75rem;
+        padding: 1rem 1.25rem;
+        margin-bottom: 1.5rem;
+      }
+      .errors {
+        background: #fee2e2;
+        border-left: 4px solid #ef4444;
+        border-radius: 0.5rem;
+        padding: 1rem 1.25rem;
+        margin-top: 1.5rem;
+        color: #b91c1c;
+      }
+      .success {
+        background: #dcfce7;
+        border-left: 4px solid #16a34a;
+        border-radius: 0.5rem;
+        padding: 1rem 1.25rem;
+        margin-top: 1.5rem;
+        color: #166534;
+      }
+      ul {
+        padding-left: 1.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Person Group 訓練工具</h1>
+      <p>
+        透過這個頁面可以替指定的會員 ID 上傳多張臉部照片，先行訓練 Azure Face
+        Person Group，讓現場設備能更快辨識回訪顧客。
+      </p>
+      <p><a href="{{ url_for('index') }}">返回首頁說明頁</a></p>
+
+      {% if not context.azure_enabled %}
+      <div class="notice">
+        {% if context.azure_person_group_error %}
+        ⚠️ {{ context.azure_person_group_error }}
+        {% elif not context.azure_configured %}
+        ⚠️ 目前尚未設定 AZURE_FACE_ENDPOINT / AZURE_FACE_KEY，無法呼叫 Azure Face
+        Person Group API。
+        {% else %}
+        ⚠️ Azure Face Person Group 功能已停用，僅保留臉部偵測與描述。
+        {% endif %}
+      </div>
+      {% endif %}
+
+      <form method="post" enctype="multipart/form-data">
+        <div class="form-group">
+          <label for="member_id">會員 ID</label>
+          <input
+            id="member_id"
+            type="text"
+            name="member_id"
+            required
+            value="{{ context.member_id }}"
+            placeholder="例如：MEM000123"
+          />
+        </div>
+        <div class="form-group">
+          <label for="images">臉部照片（可複選，多張將依序加入）</label>
+          <input id="images" type="file" name="images" accept="image/*" multiple required />
+        </div>
+        <button type="submit">上傳並訓練 Person Group</button>
+      </form>
+
+      {% if context.results %}
+      <div class="success">
+        <p>
+          已為會員 <strong>{{ context.member_id }}</strong>
+          {% if context.azure_person_id %}
+          （Azure Person ID：<code>{{ context.azure_person_id }}</code>）
+          {% endif %}
+          加入 {{ context.faces_registered }} 張臉部影像。
+          {% if context.created_member %}同時也建立了新的會員資料紀錄。{% endif %}
+        </p>
+        <p>以下檔案已成功註冊：</p>
+        <ul>
+          {% for item in context.results %}
+          <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+
+      {% if context.errors %}
+      <div class="errors">
+        <p>發生以下問題：</p>
+        <ul>
+          {% for error in context.errors %}
+          <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/backend/tests/test_upload_face.py
+++ b/backend/tests/test_upload_face.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ..ai import AdCreative, AzureFaceError, FaceAnalysis
+from ..app import app as flask_app
+from ..database import Database
+from ..recognizer import FaceEncoding, FaceRecognizer
+
+
+class FlakyAzureFace:
+    """Test double that mimics the Azure Face interface."""
+
+    def __init__(self, description: str = "短髮微笑顧客", fail_first: bool = False) -> None:
+        self.description = description
+        self.fail_first = fail_first
+        self.calls = 0
+        self.register_calls = 0
+        self.add_face_calls = 0
+        self.trained_calls = 0
+        self.person_id: str | None = None
+        self.registered_member: str | None = None
+        self.faces_added: list[bytes] = []
+        self.face_list_add_calls = 0
+        self.find_similar_calls = 0
+        self.persisted_faces: dict[str, str] = {}
+
+    @property
+    def can_describe_faces(self) -> bool:  # pragma: no cover - simple proxy
+        return True
+
+    @property
+    def can_generate_ads(self) -> bool:  # pragma: no cover - simple proxy
+        return True
+
+    @property
+    def can_manage_person_group(self) -> bool:  # pragma: no cover - simple proxy
+        return True
+
+    @property
+    def can_use_face_list(self) -> bool:  # pragma: no cover - simple proxy
+        return True
+
+    @property
+    def person_group_error(self) -> str | None:  # pragma: no cover - simple proxy
+        return None
+
+    def analyze_face(self, image_bytes: bytes, mime_type: str = "image/jpeg") -> FaceAnalysis:
+        del mime_type
+        self.calls += 1
+        if self.fail_first and self.calls == 1:
+            raise AzureFaceError("transient failure")
+        return FaceAnalysis(
+            description=self.description,
+            face_id=f"face-{self.calls}",
+            person_id=self.person_id if self.registered_member else None,
+            person_name=self.registered_member,
+            confidence=0.9 if self.registered_member else None,
+        )
+
+    def describe_face(self, image_bytes: bytes, mime_type: str = "image/jpeg") -> str:
+        return self.analyze_face(image_bytes, mime_type).description
+
+    def register_person(self, member_id: str, image_bytes: bytes, *, user_data: str | None = None) -> str:
+        del user_data
+        self.register_calls += 1
+        self.person_id = f"person-{self.register_calls}"
+        self.registered_member = member_id
+        self.faces_added.append(image_bytes)
+        self.train_person_group()
+        return self.person_id
+
+    def add_face_to_person(self, person_id: str, image_bytes: bytes) -> None:
+        if not self.person_id or person_id != self.person_id:
+            raise AzureFaceError("unknown person")
+        self.add_face_calls += 1
+        self.faces_added.append(image_bytes)
+
+    def train_person_group(self, suppress_errors: bool = True) -> None:
+        del suppress_errors
+        self.trained_calls += 1
+
+    def add_face_to_face_list(
+        self,
+        member_id: str,
+        image_bytes: bytes,
+        *,
+        user_data: str | None = None,
+    ) -> str:
+        del user_data
+        self.face_list_add_calls += 1
+        persisted_id = f"persisted-{self.face_list_add_calls}"
+        self.persisted_faces[persisted_id] = member_id
+        self.faces_added.append(image_bytes)
+        return persisted_id
+
+    def find_similar_faces(
+        self,
+        face_id: str,
+        *,
+        max_candidates: int = 5,
+        mode: str | None = None,
+    ) -> list[dict[str, object]]:
+        del face_id, max_candidates, mode
+        self.find_similar_calls += 1
+        if not self.persisted_faces:
+            return []
+        persisted_id, member_id = next(iter(self.persisted_faces.items()))
+        return [
+            {
+                "persisted_face_id": persisted_id,
+                "confidence": 0.95,
+                "member": member_id,
+            }
+        ]
+
+    def find_person_id_by_name(self, member_name: str) -> str | None:
+        if self.registered_member == member_name:
+            return self.person_id
+        return None
+
+    def generate_ad_copy(self, member_id: str, purchases):  # pragma: no cover - unused by test
+        return AdCreative(
+            headline=f"會員 {member_id}，歡迎回來！",
+            subheading="專屬優惠等你",
+            highlight="今日下單享免運",
+        )
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    database = Database(tmp_path / "test.sqlite3")
+    service = FlakyAzureFace()
+    recognizer = FaceRecognizer(service)
+
+    monkeypatch.setattr("backend.app.database", database)
+    monkeypatch.setattr("backend.app.face_service", service)
+    monkeypatch.setattr("backend.app.recognizer", recognizer)
+
+    flask_app.config.update(TESTING=True)
+    with flask_app.test_client() as test_client:
+        yield test_client, service, database
+
+
+def _post_image(test_client, payload: bytes):
+    return test_client.post(
+        "/upload_face",
+        data=payload,
+        content_type="image/jpeg",
+    )
+
+
+def test_reuse_member_id_and_serialisation(client):
+    test_client, service, database = client
+    image_payload = b"fake-image-data"
+
+    response = _post_image(test_client, image_payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["new_member"] is True
+    member_id = data["member_id"]
+
+    with database._connect() as conn:  # pylint: disable=protected-access
+        row = conn.execute(
+            "SELECT encoding_json FROM members WHERE member_id = ?",
+            (member_id,),
+        ).fetchone()
+    assert row is not None
+    stored_encoding = json.loads(row["encoding_json"])
+    assert stored_encoding["face_description"] == service.description
+    assert stored_encoding["source"] == "azure-person-group"
+    assert stored_encoding["azure_person_id"] == "person-1"
+    assert stored_encoding["azure_person_name"] == member_id
+    assert stored_encoding["azure_face_id"] == "face-1"
+    assert stored_encoding["azure_persisted_face_id"] == "persisted-1"
+    assert "gemini_description" not in stored_encoding
+
+    response_again = _post_image(test_client, image_payload)
+    assert response_again.status_code == 200
+    data_again = response_again.get_json()
+    assert data_again["status"] == "ok"
+    assert data_again["member_id"] == member_id
+    assert data_again["new_member"] is False
+    assert service.calls == 2
+    assert service.register_calls == 1
+    assert service.find_similar_calls >= 1
+    assert service.face_list_add_calls >= 1
+
+
+def test_person_group_training_creates_member(client):
+    test_client, service, database = client
+
+    response = test_client.post(
+        "/person-group",
+        data={
+            "member_id": "VIP001",
+            "images": [
+                (io.BytesIO(b"face-one"), "one.jpg", "image/jpeg"),
+                (io.BytesIO(b"face-two"), "two.jpg", "image/jpeg"),
+            ],
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    assert service.register_calls == 1
+    assert service.add_face_calls == 1
+    assert service.trained_calls >= 1
+    assert service.face_list_add_calls == 2
+
+    encoding = database.get_member_encoding("VIP001")
+    assert encoding is not None
+    assert encoding.azure_person_id == "person-1"
+    assert encoding.azure_person_name == "VIP001"
+    assert encoding.source == "azure-person-group"
+    assert encoding.azure_persisted_face_id == "persisted-1"
+
+
+def test_person_group_training_updates_existing_person(client):
+    test_client, service, database = client
+
+    existing = FaceEncoding(
+        vector=np.zeros(128, dtype=np.float32),
+        face_description="existing",
+        source="seed",
+        azure_person_id="person-5",
+        azure_person_name="VIP777",
+    )
+    database.create_member(existing, member_id="VIP777")
+
+    service.person_id = "person-5"
+    service.registered_member = "VIP777"
+
+    response = test_client.post(
+        "/person-group",
+        data={
+            "member_id": "VIP777",
+            "images": [
+                (io.BytesIO(b"face-a"), "a.jpg", "image/jpeg"),
+                (io.BytesIO(b"face-b"), "b.jpg", "image/jpeg"),
+            ],
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    assert service.register_calls == 0
+    assert service.add_face_calls == 2
+    assert service.trained_calls == 1
+    assert service.face_list_add_calls == 2
+
+    updated = database.get_member_encoding("VIP777")
+    assert updated is not None
+    assert updated.azure_person_id == "person-5"
+    assert updated.azure_person_name == "VIP777"
+    assert updated.source == "azure-person-group"
+    assert updated.azure_persisted_face_id == "persisted-1"


### PR DESCRIPTION
## Summary
- extend the Azure Face wrapper to manage face lists, add faces via REST or SDK, and call findSimilar for recognition without person-group approvals
- store Azure face IDs and persisted face-list IDs in the recognizer/database and teach the upload and trainer flows to add faces to the list while reusing matches from findSimilar
- document the new AZURE_FACE_LIST_ID env var and refresh the tests to cover the face list stub workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38ae12c1c8322a6eba61624c96cda