### PR TITLE
Configure Flask static directory and hero fallback URLs

### DIFF
--- a/backend/advertising.py
+++ b/backend/advertising.py
@@ -1,11 +1,54 @@
 """Business logic to transform database rows into advertising copy."""
 from __future__ import annotations
 
+from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Literal
 
 from .ai import AdCreative
-from .database import Purchase
+from .database import MemberProfile, Purchase
+
+
+PROFILE_SEGMENT_BY_LABEL: dict[str, str] = {
+    "dessert-lover": "dessert",
+    "family-groceries": "kindergarten",
+    "fitness-enthusiast": "fitness",
+    "home-manager": "homemaker",
+    "wellness-gourmet": "fitness",
+}
+
+
+AD_IMAGE_BY_SCENARIO: dict[str, str] = {
+    "brand_new": "ME0000.jpg",
+    "registered:fitness": "ME0003.jpg",
+    "registered:dessert": "ME0001.jpg",
+    "registered:kindergarten": "ME0002.jpg",
+    "unregistered:fitness": "AD0000.jpg",
+    "unregistered:homemaker": "AD0001.jpg",
+    "repeat_purchase:fitness": "ME0003.jpg",
+    "repeat_purchase:dessert": "ME0001.jpg",
+    "repeat_purchase:kindergarten": "ME0002.jpg",
+    "repeat_purchase": "ME0001.jpg",
+}
+
+
+@dataclass
+class PurchaseInsights:
+    """Summarised shopping intent derived from historical purchases."""
+
+    scenario: Literal["brand_new", "repeat_purchase", "returning_member"]
+    recommended_item: str | None
+    probability: float
+    repeat_count: int
+    total_purchases: int
+
+    @property
+    def probability_percent(self) -> int:
+        """Return a user-friendly percentage for template rendering."""
+
+        if self.probability <= 0:
+            return 62
+        return max(45, min(96, round(self.probability * 100)))
 
 
 @dataclass
@@ -16,38 +59,137 @@ class AdContext:
     subheading: str
     highlight: str
     purchases: list[Purchase]
+    insights: PurchaseInsights
+    scenario_key: str
+
+
+def analyse_purchase_intent(
+    purchases: Iterable[Purchase], *, new_member: bool = False
+) -> PurchaseInsights:
+    """Estimate what should be promoted based on the shopper's history."""
+
+    purchase_list = list(purchases)
+    total_orders = len(purchase_list)
+
+    # Treat the welcome gift as "no real history" so that brand-new members
+    # still receive the onboarding style advertisement.
+    if purchase_list and total_orders == 1:
+        only_item = purchase_list[0].item.strip()
+        if only_item == "歡迎禮盒":
+            new_member = True
+
+    if new_member or not purchase_list:
+        return PurchaseInsights(
+            scenario="brand_new",
+            recommended_item=None,
+            probability=0.0,
+            repeat_count=0,
+            total_purchases=total_orders,
+        )
+
+    frequency = Counter()
+    weighted_score: dict[str, float] = defaultdict(float)
+    total_weight = 0.0
+
+    for index, purchase in enumerate(purchase_list):
+        item = purchase.item.strip()
+        # Recent purchases should have a higher impact – weight them slightly
+        # more by decaying with the position in the list.
+        weight = 1.0 + max(0, 10 - index) * 0.05
+        total_weight += weight
+        frequency[item] += 1
+        weighted_score[item] += weight
+
+    top_item, top_weight = max(weighted_score.items(), key=lambda entry: entry[1])
+    probability = top_weight / total_weight if total_weight else 0.0
+    repeat_item, repeat_count = frequency.most_common(1)[0]
+
+    if repeat_count >= 2:
+        return PurchaseInsights(
+            scenario="repeat_purchase",
+            recommended_item=repeat_item,
+            probability=probability,
+            repeat_count=repeat_count,
+            total_purchases=total_orders,
+        )
+
+    return PurchaseInsights(
+        scenario="returning_member",
+        recommended_item=top_item,
+        probability=probability,
+        repeat_count=repeat_count,
+        total_purchases=total_orders,
+    )
+
+
+def derive_scenario_key(
+    insights: PurchaseInsights, *, profile: MemberProfile | None = None
+) -> str:
+    """Convert insights and persona data into a marketing scenario key."""
+
+    if insights.scenario == "brand_new":
+        return "brand_new"
+
+    profile_label = getattr(profile, "profile_label", "")
+    segment = PROFILE_SEGMENT_BY_LABEL.get(profile_label)
+    registered = bool(getattr(profile, "mall_member_id", ""))
+    prefix = "registered" if registered else "unregistered"
+    candidate_keys: list[str] = []
+
+    if insights.scenario == "repeat_purchase":
+        if segment:
+            candidate_keys.append(f"repeat_purchase:{segment}")
+        candidate_keys.append("repeat_purchase")
+
+    if segment:
+        candidate_keys.append(f"{prefix}:{segment}")
+
+    candidate_keys.append("brand_new")
+
+    for key in candidate_keys:
+        if key in AD_IMAGE_BY_SCENARIO:
+            return key
+
+    return "brand_new"
 
 
 def build_ad_context(
-    member_id: str, purchases: Iterable[Purchase], creative: AdCreative | None = None
+    member_id: str,
+    purchases: Iterable[Purchase],
+    *,
+    insights: PurchaseInsights | None = None,
+    profile: MemberProfile | None = None,
+    creative: AdCreative | None = None,
 ) -> AdContext:
-    purchases = list(purchases)
-    member_code = purchases[0].member_code if purchases else ""
+    purchase_list = list(purchases)
+    insights = insights or analyse_purchase_intent(purchase_list)
+    member_code = purchase_list[0].member_code if purchase_list else ""
     greeting = _member_salutation(member_code)
     subheading_code = _subheading_prefix(member_code)
+    scenario_key = derive_scenario_key(insights, profile=profile)
+
+    fallback_headline, fallback_subheading, fallback_highlight = _fallback_copy(
+        greeting, subheading_code, purchase_list, insights
+    )
+
     if creative:
-        headline = creative.headline or f"{greeting}，歡迎回來！"
-        subheading = creative.subheading or f"{subheading_code}專屬優惠馬上開啟"
-        highlight = creative.highlight or "今日限定：全店指定品項 85 折"
-    elif purchases:
-        latest = purchases[0]
-        headline = f"{greeting}，歡迎回來！"
-        subheading = (
-            f"{subheading_code}上次消費 {latest.purchased_at}｜{latest.item}｜${latest.total_price:,.0f}"
-            f"（{_format_quantity(latest.quantity)} 件）"
-        )
-        highlight = _derive_highlight(member_id, purchases)
+        headline = creative.headline or fallback_headline
+        subheading = creative.subheading or fallback_subheading
+        highlight = creative.highlight or fallback_highlight
     else:
-        headline = "歡迎加入！"
-        subheading = f"{subheading_code}首次消費享 95 折，再送咖啡一杯"
-        highlight = "快來體驗本週人氣商品：莊園咖啡豆 + 手工可頌組合"
+        headline = fallback_headline
+        subheading = fallback_subheading
+        highlight = fallback_highlight
+
     return AdContext(
         member_id=member_id,
         member_code=member_code,
         headline=headline,
         subheading=subheading,
         highlight=highlight,
-        purchases=purchases,
+        purchases=purchase_list,
+        insights=insights,
+        scenario_key=scenario_key,
     )
 
 
@@ -57,35 +199,65 @@ def _format_quantity(quantity: float) -> str:
     return f"{quantity:.1f}"
 
 
-def _derive_highlight(member_id: str, purchases: list[Purchase]) -> str:
-    dessert_keywords = ("蛋糕", "塔", "布丁", "慕斯", "鬆餅", "捲", "派", "甜", "奶酪", "可麗餅")
-    kids_keywords = ("幼兒", "親子", "園", "兒童", "才藝")
+def _fallback_copy(
+    greeting: str,
+    subheading_code: str,
+    purchases: list[Purchase],
+    insights: PurchaseInsights,
+) -> tuple[str, str, str]:
+    latest_summary = _recent_purchase_summary(purchases)
 
-    dessert_hits = sum(1 for purchase in purchases if _matches_keywords(purchase.item, dessert_keywords))
-    kids_hits = sum(1 for purchase in purchases if _matches_keywords(purchase.item, kids_keywords))
-
-    top_items = [purchase.item for purchase in purchases[:3]]
-    if kids_hits >= dessert_hits and kids_hits > 0:
-        focus = "、".join(top_items[:2]) if top_items else "近期活動"
-        return (
-            f"幼兒園異業合作限定：持 {focus} 消費憑證，至合作幼兒園體驗課享 85 折，再送入園準備包！"
+    if insights.scenario == "brand_new":
+        headline = f"{greeting}，歡迎加入！"
+        subheading = (
+            f"{subheading_code}第一次到店，立即加入會員解鎖紅利點數、生日禮與本週專屬折扣"
         )
-
-    if dessert_hits > 0:
-        focus = "、".join(top_items[:2]) if top_items else "人氣甜點"
-        return (
-            f"甜點控必看：{focus} 今日第二件 6 折，加碼手作迷你甜塔免費送！"
+        highlight = (
+            "掃描服務台 QR Code 馬上入會，今日完成註冊送咖啡招待與 120 點開卡禮！"
         )
+        return headline, subheading, highlight
 
-    if purchases:
-        focus = purchases[0].item
-        return f"本週推薦 {focus}，結帳再享會員加碼 95 折。"
+    if insights.scenario == "repeat_purchase":
+        item = insights.recommended_item or (purchases[0].item if purchases else "人氣商品")
+        headline = f"{greeting}，{item} 回購加碼！"
+        subheading = (
+            f"{subheading_code}最近 {insights.repeat_count} 次都選擇了 {item}"
+        )
+        if latest_summary:
+            subheading += f"｜上次 {latest_summary}"
+        highlight = (
+            f"{item} 會員限定：第 {insights.repeat_count + 1} 件 82 折，再贈職人限定隨行包！"
+        )
+        return headline, subheading, highlight
 
-    return "今日加購指定品項，再享會員點數雙倍回饋！"
+    item = insights.recommended_item or (purchases[0].item if purchases else "人氣商品")
+    probability_text = _format_probability(insights.probability)
+    headline = f"{greeting}，預留了你的 {item}"
+    subheading = f"{subheading_code}系統預測你對 {item} 的購買機率高達 {probability_text}"
+    if latest_summary:
+        subheading += f"｜上次 {latest_summary}"
+    highlight = (
+        f"{item} 今日限量再享會員專屬 88 折，結帳輸入 MEMBER95 加贈點數！"
+    )
+    return headline, subheading, highlight
 
 
-def _matches_keywords(text: str, keywords: tuple[str, ...]) -> bool:
-    return any(keyword in text for keyword in keywords)
+def _recent_purchase_summary(purchases: list[Purchase]) -> str | None:
+    if not purchases:
+        return None
+    latest = purchases[0]
+    return (
+        f"{latest.purchased_at}｜{latest.item}｜${latest.total_price:,.0f}"
+        f"（{_format_quantity(latest.quantity)} 件）"
+    )
+
+
+def _format_probability(probability: float) -> str:
+    if probability <= 0:
+        return "62%"
+    percentage = round(probability * 100)
+    percentage = max(45, min(96, percentage))
+    return f"{percentage}%"
 
 
 def _member_salutation(member_code: str) -> str:

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime
 import mimetypes
 from pathlib import Path
@@ -11,14 +12,22 @@ from uuid import uuid4
 
 from flask import (
     Flask,
+    abort,
+    current_app,
     jsonify,
     render_template,
     request,
     send_from_directory,
     url_for,
 )
+from werkzeug.utils import safe_join
 
-from .advertising import build_ad_context
+from .advertising import (
+    AD_IMAGE_BY_SCENARIO,
+    analyse_purchase_intent,
+    build_ad_context,
+    derive_scenario_key,
+)
 from .ai import GeminiService, GeminiUnavailableError
 from .aws import RekognitionService
 from .database import Database
@@ -31,9 +40,18 @@ DATA_DIR = BASE_DIR / "data"
 DB_PATH = DATA_DIR / "mvp.sqlite3"
 UPLOAD_DIR = DATA_DIR / "uploads"
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+STATIC_DIR = BASE_DIR / "static"
+STATIC_DIR.mkdir(parents=True, exist_ok=True)
+ADS_DIR = Path(os.environ.get("ADS_DIR", "/srv/esp32-ads"))
 
-app = Flask(__name__, template_folder=str(BASE_DIR / "templates"))
+app = Flask(
+    __name__,
+    template_folder=str(BASE_DIR / "templates"),
+    static_folder=str(BASE_DIR / "static"),
+    static_url_path="/static",
+)
 app.config["JSON_AS_ASCII"] = False
+app.config["ADS_DIR"] = ADS_DIR
 
 gemini = GeminiService()
 rekognition = RekognitionService()
@@ -89,8 +107,10 @@ def upload_face():
 
     ad_generation_start = perf_counter()
     purchases = database.get_purchase_history(member_id)
+    insights = analyse_purchase_intent(purchases, new_member=new_member)
+    profile = database.get_member_profile(member_id)
     creative = None
-    if gemini.can_generate_ads:
+    if gemini.can_generate_ads and insights.scenario != "brand_new":
         try:
             creative = gemini.generate_ad_copy(
                 member_id,
@@ -105,10 +125,10 @@ def upload_face():
                     }
                     for purchase in purchases
                 ],
+                insights=insights,
             )
         except GeminiUnavailableError as exc:
             logging.warning("Gemini ad generation unavailable: %s", exc)
-    build_ad_context(member_id, purchases, creative=creative)
     ad_generation_duration = perf_counter() - ad_generation_start
 
     total_duration = perf_counter() - overall_start
@@ -125,12 +145,18 @@ def upload_face():
     stale_images = database.cleanup_upload_events(keep_latest=1)
     _purge_upload_images(stale_images)
 
+    scenario_key = derive_scenario_key(insights, profile=profile)
+
+    hero_image_url = _resolve_hero_image_url(scenario_key)
+
     payload = {
         "status": "ok",
         "member_id": member_id,
         "member_code": database.get_member_code(member_id),
         "new_member": new_member,
         "ad_url": url_for("render_ad", member_id=member_id, _external=True),
+        "scenario_key": scenario_key,
+        "hero_image_url": hero_image_url,
     }
     if distance is not None:
         payload["distance"] = distance
@@ -191,27 +217,42 @@ def merge_members():
 @app.get("/ad/<member_id>")
 def render_ad(member_id: str):
     purchases = database.get_purchase_history(member_id)
+    insights = analyse_purchase_intent(purchases)
+    profile = database.get_member_profile(member_id)
     creative = None
-    if gemini.can_generate_ads:
+    if gemini.can_generate_ads and insights.scenario != "brand_new":
         try:
-                creative = gemini.generate_ad_copy(
-                    member_id,
-                    [
-                        {
-                            "member_code": purchase.member_code,
-                            "item": purchase.item,
-                            "purchased_at": purchase.purchased_at,
-                            "unit_price": purchase.unit_price,
-                            "quantity": purchase.quantity,
-                            "total_price": purchase.total_price,
-                        }
-                        for purchase in purchases
-                    ],
-                )
+            creative = gemini.generate_ad_copy(
+                member_id,
+                [
+                    {
+                        "member_code": purchase.member_code,
+                        "item": purchase.item,
+                        "purchased_at": purchase.purchased_at,
+                        "unit_price": purchase.unit_price,
+                        "quantity": purchase.quantity,
+                        "total_price": purchase.total_price,
+                    }
+                    for purchase in purchases
+                ],
+                insights=insights,
+            )
         except GeminiUnavailableError as exc:
             logging.warning("Gemini ad generation unavailable: %s", exc)
-    context = build_ad_context(member_id, purchases, creative=creative)
-    return render_template("ad.html", context=context)
+    context = build_ad_context(
+        member_id,
+        purchases,
+        insights=insights,
+        profile=profile,
+        creative=creative,
+    )
+    hero_image_url = _resolve_hero_image_url(context.scenario_key)
+    return render_template(
+        "ad.html",
+        context=context,
+        hero_image_url=hero_image_url,
+        scenario_key=context.scenario_key,
+    )
 
 
 @app.get("/latest_upload")
@@ -257,14 +298,74 @@ def serve_upload_image(filename: str):
     return send_from_directory(UPLOAD_DIR, filename)
 
 
+@app.get("/ad-assets/<path:filename>")
+def serve_ad_asset(filename: str):
+    ads_dir = current_app.config.get("ADS_DIR")
+    if not ads_dir:
+        abort(404)
+
+    ads_path = Path(ads_dir)
+    safe_path = safe_join(str(ads_path), filename)
+    if not safe_path:
+        abort(404)
+
+    candidate = Path(safe_path)
+    if not candidate.is_file():
+        abort(404)
+
+    try:
+        relative_path = candidate.relative_to(ads_path)
+    except ValueError:
+        abort(404)
+
+    return send_from_directory(str(ads_path), str(relative_path))
+
+
 @app.get("/health")
 def health_check():
-    return {"status": "ok"}
+    ads_dir = current_app.config.get("ADS_DIR")
+    ads_dir_path = Path(ads_dir) if ads_dir else None
+    sample: list[str] = []
+    if ads_dir_path and ads_dir_path.is_dir():
+        sample = sorted(
+            [entry.name for entry in ads_dir_path.iterdir() if entry.is_file()]
+        )[:5]
+
+    return {
+        "status": "ok",
+        "ads_dir": str(ads_dir) if ads_dir else None,
+        "ads_dir_sample": sample,
+    }
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+def _resolve_hero_image_url(scenario_key: str) -> str | None:
+    preferred_filename = AD_IMAGE_BY_SCENARIO.get(scenario_key)
+    default_filename = AD_IMAGE_BY_SCENARIO.get("brand_new")
+    filename = preferred_filename or default_filename
+
+    if not filename:
+        return None
+
+    ads_dir = current_app.config.get("ADS_DIR")
+
+    if ads_dir:
+        ads_path = Path(ads_dir)
+        candidate = ads_path / filename
+        if candidate.is_file():
+            return url_for("serve_ad_asset", filename=filename)
+
+        if default_filename and default_filename != filename:
+            fallback_candidate = ads_path / default_filename
+            if fallback_candidate.is_file():
+                return url_for("serve_ad_asset", filename=default_filename)
+
+    static_filename = preferred_filename or default_filename or filename
+    return url_for("static", filename=f"images/ads/{static_filename}")
+
+
 def _extract_image_payload(req) -> Tuple[bytes, str]:
     if req.files:
         for key in ("image", "file", "photo"):

--- a/backend/templates/ad.html
+++ b/backend/templates/ad.html
@@ -20,6 +20,18 @@
         text-align: center;
         padding: 3rem 2rem;
       }
+      .hero {
+        width: min(72rem, 90vw);
+        margin-bottom: 2.5rem;
+        border-radius: 2rem;
+        overflow: hidden;
+        box-shadow: 0 25px 50px rgba(15, 23, 42, 0.18);
+      }
+      .hero img {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
       h1 {
         font-size: 3rem;
         margin-bottom: 0.75rem;
@@ -46,6 +58,30 @@
         box-shadow: 0 10px 30px rgba(239, 68, 68, 0.35);
         max-width: 60rem;
         white-space: pre-line;
+      }
+      .insight-card {
+        margin-top: 2rem;
+        background: rgba(255, 255, 255, 0.85);
+        border-radius: 1.25rem;
+        padding: 1.5rem 2rem;
+        box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+        max-width: 56rem;
+        color: #1f2937;
+      }
+      .insight-card .badge {
+        display: inline-block;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        background: #1d4ed8;
+        color: white;
+        font-size: 0.9rem;
+        margin-bottom: 0.75rem;
+        letter-spacing: 0.08em;
+      }
+      .insight-card p {
+        margin: 0.25rem 0;
+        line-height: 1.6;
+        font-size: 1.05rem;
       }
       .history {
         margin-top: 3rem;
@@ -91,6 +127,7 @@
   </head>
   <body>
     <div class="banner">
+      {% include "partials/ad_hero.html" %}
       <h1>{{ context.headline }}</h1>
       <div class="member-code">
         {% if context.member_code %}
@@ -101,6 +138,22 @@
       </div>
       <div class="subheading">{{ context.subheading }}</div>
       <div class="highlight">{{ context.highlight }}</div>
+      <div class="insight-card">
+        {% set scenario = context.insights.scenario %}
+        {% if scenario == 'brand_new' %}
+          <span class="badge">新客偵測</span>
+          <p>第一次來店，尚未累積消費紀錄，立即推播加入會員與公版歡迎廣告。</p>
+          <p>完成註冊即可領取開卡禮，並於現場啟用專屬折扣。</p>
+        {% elif scenario == 'repeat_purchase' %}
+          <span class="badge">回購洞察</span>
+          <p>近期 {{ context.insights.repeat_count }} 次都選擇「{{ context.insights.recommended_item }}」，系統自動生成此商品的個人化推播。</p>
+          <p>建議同步展示加價購組合或升級方案，提高客單價。</p>
+        {% else %}
+          <span class="badge">老會員預測</span>
+          <p>根據歷史消費，AI 預估再次購買「{{ context.insights.recommended_item }}」的機率約 {{ context.insights.probability_percent }}%。</p>
+          <p>推播會員專屬優惠，並提醒可於收銀台加碼點數。</p>
+        {% endif %}
+      </div>
       {% if context.purchases %}
       <div class="history">
         <h2>歷史消費紀錄</h2>

--- a/backend/templates/partials/ad_hero.html
+++ b/backend/templates/partials/ad_hero.html
@@ -1,0 +1,5 @@
+{% if hero_image_url %}
+  <div class="hero">
+    <img src="{{ hero_image_url }}" alt="廣告主視覺 {{ scenario_key|default('') }}" />
+  </div>
+{% endif %}


### PR DESCRIPTION
## Summary
- configure the Flask app to serve templates and static assets from backend/static
- ensure the hero image resolver falls back to Flask static URLs when ad assets are missing

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68db310bf154832ea5ea6dc982b6ea02