### PR TITLE
Add purchase prediction dashboard and catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,45 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
     - `GET /health`：基本健康檢查。
     - `POST /members/merge`：手動修正重複會員。請帶入 `{"source": "MEM001", "target": "MEM002"}`，系統會把來源會員的消費紀錄與 Rekognition 雲端索引合併到目標會員下。
 
-6. 服務啟動時會先刪除並重建 Amazon Rekognition 人臉集合，確保所有雲端特徵從零開始訓練；同時 SQLite 也會重設
+6. 商品目錄與預測邏輯：
+
+   - `backend/catalogue.py` 以品類為單位維護商品清單，並針對不同族群給定固定前綴的商品編號：
+     - `DES###`：精緻甜點（Dessert）
+     - `FIT###`：運動健身（Fitness）
+     - `KID###`：幼兒教養（Kindergarten）
+     - `HOM###`：家居生活（Homemaker）
+     - `GEN###`：生活選品（General）
+   - 每個商品皆附帶基礎查閱率（View Rate）與售價資訊，方便預測模組產生 UI 所需欄位。
+   - 透過 `infer_category_from_item()` 將歷史訂單名稱對應回目錄品類，確保跨模組一致性。
+
+7. 機率計算公式：
+
+   - `backend/prediction.py` 會取出「上一個月」的消費紀錄，若該月份沒有資料則回退至最近一個有紀錄的月份。
+   - 針對所有候選商品計算分數：
+
+     ```text
+     score = 0.45 * category_weight
+           + 0.25 * recency_bonus
+           + 0.20 * price_similarity
+           + 0.10 * novelty
+     ```
+
+     - `category_weight`：當月各品類的購買比重（頻率正規化）。
+     - `recency_bonus`：依據最近 5 筆交易的品類倒序加權（越新的比重越高）。
+     - `price_similarity`：商品售價與歷史平均單價的差異，越接近越高。
+     - `novelty`：未購買過的新商品加權 1.0，已出現過則降至 0.3，會員身份再額外帶入 0.8 的基礎值。
+   - 將上述分數送入 softmax 取得 `probability`，並四捨五入至 0.1% 輸出 `probability_percent`；查閱率亦以 0.1% 顯示。
+
+8. 驗證介面：
+
+   - 管理者頁面：`http://<server-ip>:8000/manager`，預設載入第一位有會員 ID 的顧客，可透過下拉選單切換其他人員。此頁面會呈現：
+     1. ESP32-CAM 上傳的顧客影像（若未有首張影像則使用 hero fallback）。
+     2. 本月潛在熱銷清單（七筆）、上一期熱銷前三名與上一個月的消費紀錄。
+     3. 會員基本資料、職業 / 產業別欄位與參與活動紀錄。
+   - 顧客端廣告頁：`GET /ad/<member_id>?v2=1` 可直接預覽新版樣式；若需要除錯，可加上 `&debug=1` 觀察 hero 圖來源與情境代碼。
+   - 若要重跑推薦邏輯，可從 VM 目錄中挑任一張測試照片呼叫 `/upload_face`，後台會自動辨識身份、寫入上一個月資料並更新上述兩個畫面。
+
+9. 服務啟動時會先刪除並重建 Amazon Rekognition 人臉集合，確保所有雲端特徵從零開始訓練；同時 SQLite 也會重設
    `member_profiles` 中預留的五筆示範資料，讓 `member_id` 欄位保持空白。辨識到新臉孔時，系統會先以空集合比對，
    若找不到則建立匿名 `MEMxxxxxxxxxx` 會員、寫入歡迎禮並將影像訓練進集合，然後由程式自動把最新 5 位新會員
    依序填入預留的示範資料列。示範資料涵蓋甜點收藏家、幼兒園家長、健身族、家庭採買者與健康養生客層，其中
@@ -87,14 +125,14 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
    其中一筆預留資料，系統會立即灌入對應的 2025 年消費紀錄並延續後續流程；待五筆都完成綁定後，新的臉孔就會
    依照一般規則自動生成新的系統編號與歷史資料。
 
-7. 修正重複會員：若同一張臉誤判成不同會員，可呼叫 `POST /members/merge`，將重複的會員 ID 合併。API 會：
+10. 修正重複會員：若同一張臉誤判成不同會員，可呼叫 `POST /members/merge`，將重複的會員 ID 合併。API 會：
 
    1. 將來源會員 (`source`) 的所有消費紀錄轉移到目標會員 (`target`)。
    2. 從 SQLite 刪除來源會員。
    3. 透過 Amazon Rekognition 刪除來源會員的 `ExternalImageId`，避免後續再命中舊編號。
    4. 如果來源的雲端特徵較完整（或設定 `"prefer_source_encoding": true`），會自動覆蓋目標會員的特徵值，確保未來比對以正確編號返回。
 
-8. 手動測試（使用任何 JPEG）：
+11. 手動測試（使用任何 JPEG）：
 
    ```bash
    curl -X POST \

--- a/backend/advertising.py
+++ b/backend/advertising.py
@@ -32,7 +32,7 @@ AD_IMAGE_BY_SCENARIO: dict[str, str] = {
     "repeat_purchase:dessert": "ME0001.jpg",
     "repeat_purchase:kindergarten": "ME0002.jpg",
     "repeat_purchase:fitness": "ME0003.jpg",
-    "repeat_purchase": "ME0001.jpg",  # 無類別時的備援
+    "repeat_purchase": "ME0003.jpg",  # 無類別時的備援
 
     # 3) 未註冊會員但有明顯偏好（引導入會）
     "unregistered:fitness": "AD0000.jpg",
@@ -129,24 +129,23 @@ def derive_scenario_key(
         return "brand_new"
 
     profile_label = getattr(profile, "profile_label", "")
-    segment = PROFILE_SEGMENT_BY_LABEL.get(profile_label, "general")
+    segment = PROFILE_SEGMENT_BY_LABEL.get(profile_label, "")
     registered = bool(getattr(profile, "mall_member_id", ""))
 
-    # 優先用會員狀態 + persona 分群來挑 hero 圖
-    prefix = "registered" if registered else "unregistered"
-    scenario_key = f"{prefix}:{segment}"
-    if scenario_key in AD_IMAGE_BY_SCENARIO:
-        return scenario_key
+    if segment:
+        prefix = "registered" if registered else "unregistered"
+        scenario_key = f"{prefix}:{segment}"
+        if scenario_key in AD_IMAGE_BY_SCENARIO:
+            return scenario_key
 
-    # 若 persona 無法對到既有分群，嘗試用回購情境附加類別（若上層有實作）
     if insights.scenario.startswith("repeat_purchase"):
-        rp_key = f"repeat_purchase:{segment}"
-        if rp_key in AD_IMAGE_BY_SCENARIO:
-            return rp_key
+        if segment:
+            rp_key = f"repeat_purchase:{segment}"
+            if rp_key in AD_IMAGE_BY_SCENARIO:
+                return rp_key
         if "repeat_purchase" in AD_IMAGE_BY_SCENARIO:
             return "repeat_purchase"
 
-    # 最終退回新客圖，避免空白
     return "brand_new"
 
 def build_ad_context(

--- a/backend/catalogue.py
+++ b/backend/catalogue.py
@@ -1,0 +1,216 @@
+"""Central catalogue definitions for the ESP32-CAM retail demo."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Sequence
+
+
+@dataclass(frozen=True)
+class Product:
+    """Immutable catalogue entry."""
+
+    code: str
+    name: str
+    category: str
+    price: float
+    view_rate: float  # expressed as 0-1 ratio
+
+
+CATEGORY_PREFIXES: dict[str, str] = {
+    "dessert": "DES",
+    "fitness": "FIT",
+    "kindergarten": "KID",
+    "homemaker": "HOM",
+    "general": "GEN",
+}
+
+CATEGORY_LABELS: dict[str, str] = {
+    "dessert": "精緻甜點",
+    "fitness": "運動健身",
+    "kindergarten": "幼兒教養",
+    "homemaker": "家居生活",
+    "general": "生活選品",
+}
+
+_CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "dessert": (
+        "蛋糕",
+        "布蕾",
+        "甜",
+        "塔",
+        "慕斯",
+        "布丁",
+        "餅乾",
+        "乳酪",
+        "可麗",
+        "麵包",
+    ),
+    "fitness": (
+        "瑜伽",
+        "健身",
+        "體能",
+        "訓練",
+        "肌力",
+        "跑步",
+        "能量",
+        "運動",
+        "瑜珈",
+        "伸展",
+    ),
+    "kindergarten": (
+        "幼兒",
+        "親子",
+        "兒童",
+        "才藝",
+        "園",
+        "課",
+        "積木",
+        "繪本",
+        "童",
+    ),
+    "homemaker": (
+        "家用",
+        "清潔",
+        "廚房",
+        "香氛",
+        "收納",
+        "濾水",
+        "補充包",
+        "沐浴",
+        "家庭",
+        "家居",
+        "烹飪",
+    ),
+    "general": (
+        "咖啡",
+        "茶",
+        "禮盒",
+        "票",
+        "市集",
+        "旅行",
+        "香氛",
+    ),
+}
+
+_RAW_CATALOGUE: dict[str, Sequence[tuple[str, float, float]]] = {
+    "dessert": (
+        ("草莓千層蛋糕禮盒", 620.0, 0.72),
+        ("焦糖海鹽布蕾雙入", 210.0, 0.61),
+        ("抹茶生乳捲分享組", 560.0, 0.67),
+        ("藍莓優格慕斯杯", 260.0, 0.58),
+        ("法式莓果塔", 280.0, 0.64),
+        ("伯爵茶可麗露禮盒", 520.0, 0.69),
+        ("蜂蜜檸檬磅蛋糕", 320.0, 0.56),
+        ("玫瑰荔枝蛋糕", 360.0, 0.55),
+        ("榛果巧克力布朗尼", 240.0, 0.6),
+    ),
+    "fitness": (
+        ("高強度間歇訓練月票", 2680.0, 0.48),
+        ("智能飛輪體驗課程", 1680.0, 0.5),
+        ("肌力核心進階班", 1980.0, 0.46),
+        ("運動機能壓縮衣", 1280.0, 0.54),
+        ("能量蛋白飲禮盒", 680.0, 0.57),
+        ("瑜伽伸展一日營", 1480.0, 0.45),
+        ("體態評估與飲食諮詢", 3200.0, 0.43),
+        ("樂齡低衝擊體適能課", 1580.0, 0.47),
+        ("戶外越野跑訓練營", 2380.0, 0.44),
+    ),
+    "kindergarten": (
+        ("幼兒律動課體驗券", 720.0, 0.62),
+        ("親子烘焙下午茶套票", 1280.0, 0.6),
+        ("幼兒園夏令營報名", 5200.0, 0.58),
+        ("幼兒科學探索盒", 680.0, 0.59),
+        ("親子劇場週末票", 980.0, 0.55),
+        ("幼兒園延托服務時數", 450.0, 0.57),
+        ("幼兒才藝試上課程", 780.0, 0.6),
+        ("幼兒園校車月票", 2800.0, 0.53),
+        ("親子閱讀共學包", 920.0, 0.61),
+    ),
+    "homemaker": (
+        ("家用濾水壺含濾芯組", 950.0, 0.52),
+        ("智慧家電延長線", 420.0, 0.49),
+        ("廚房收納保鮮組", 560.0, 0.51),
+        ("家庭常備洗衣精補充包", 360.0, 0.55),
+        ("香氛擴香瓶禮盒", 620.0, 0.5),
+        ("不沾煎鍋三件組", 1880.0, 0.46),
+        ("居家舒眠香氛蠟燭", 420.0, 0.48),
+        ("智能掃拖機器人保養", 2800.0, 0.44),
+        ("家庭露營炊具套組", 1980.0, 0.45),
+    ),
+    "general": (
+        ("精品手沖咖啡體驗課", 980.0, 0.41),
+        ("城市慢旅文化導覽", 1580.0, 0.38),
+        ("當季市集嚴選蔬果箱", 880.0, 0.47),
+        ("無酒精氣泡飲禮盒", 620.0, 0.4),
+        ("手作香氛擴香課程", 1280.0, 0.39),
+        ("節慶限定禮物卡", 500.0, 0.42),
+        ("都會輕旅背包", 1380.0, 0.43),
+        ("生活選品訂閱方案", 760.0, 0.37),
+        ("永續生活工作坊", 1180.0, 0.36),
+    ),
+}
+
+
+def _build_catalogue() -> list[Product]:
+    catalogue: list[Product] = []
+    for category, items in _RAW_CATALOGUE.items():
+        prefix = CATEGORY_PREFIXES[category]
+        for index, (name, price, view_rate) in enumerate(items, start=1):
+            code = f"{prefix}{index:03d}"
+            catalogue.append(
+                Product(
+                    code=code,
+                    name=name,
+                    category=category,
+                    price=float(price),
+                    view_rate=float(view_rate),
+                )
+            )
+    return catalogue
+
+
+_CATALOGUE: tuple[Product, ...] = tuple(_build_catalogue())
+
+
+def get_catalogue() -> tuple[Product, ...]:
+    """Return the immutable catalogue."""
+
+    return _CATALOGUE
+
+
+def iter_by_category(category: str) -> Iterator[Product]:
+    normalized = category.strip().lower()
+    return (product for product in _CATALOGUE if product.category == normalized)
+
+
+def get_product_by_code(code: str) -> Product | None:
+    normalized = code.strip().upper()
+    for product in _CATALOGUE:
+        if product.code == normalized:
+            return product
+    return None
+
+
+def infer_category_from_item(name: str) -> str:
+    """Best-effort category mapping derived from the product name."""
+
+    item = name.strip()
+    lowered = item.lower()
+    for category, keywords in _CATEGORY_KEYWORDS.items():
+        if any(keyword in item or keyword in lowered for keyword in keywords):
+            return category
+    return "general"
+
+
+def category_label(category: str) -> str:
+    return CATEGORY_LABELS.get(category, "生活選品")
+
+
+def purchased_product_codes(purchases: Iterable[str]) -> set[str]:
+    known = {product.name: product.code for product in _CATALOGUE}
+    codes = set()
+    for item in purchases:
+        code = known.get(item)
+        if code:
+            codes.add(code)
+    return codes

--- a/backend/prediction.py
+++ b/backend/prediction.py
@@ -1,0 +1,263 @@
+"""Prediction helpers for estimating next-best offers."""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import exp
+from typing import Iterable, Sequence
+
+from .advertising import PurchaseInsights
+from .catalogue import (
+    CATEGORY_LABELS,
+    Product,
+    category_label,
+    get_catalogue,
+    infer_category_from_item,
+    purchased_product_codes,
+)
+from .database import MemberProfile, Purchase
+
+
+@dataclass
+class PredictedItem:
+    product_code: str
+    product_name: str
+    category: str
+    category_label: str
+    price: float
+    view_rate_percent: float
+    probability: float
+    probability_percent: float
+
+
+@dataclass
+class PredictionResult:
+    items: list[PredictedItem]
+    history: list[Purchase]
+    top_products: list[dict[str, object]]
+    activities: list[dict[str, str]]
+    window_label: str
+
+
+def parse_timestamp(value: str) -> datetime:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d %H:%M")
+    except ValueError:
+        return datetime.fromisoformat(value)
+
+
+def get_previous_month_purchases(
+    purchases: Iterable[Purchase], *, reference: datetime | None = None
+) -> list[Purchase]:
+    ordered = sorted(purchases, key=lambda purchase: parse_timestamp(purchase.purchased_at))
+    if not ordered:
+        return []
+
+    reference_dt = reference or parse_timestamp(ordered[-1].purchased_at)
+    reference_dt = reference_dt.replace(day=1)
+    previous_month = reference_dt - timedelta(days=1)
+    target_year = previous_month.year
+    target_month = previous_month.month
+
+    window: list[Purchase] = [
+        purchase
+        for purchase in ordered
+        if (
+            (ts := parse_timestamp(purchase.purchased_at)).year == target_year
+            and ts.month == target_month
+        )
+    ]
+    if window:
+        return window
+
+    buckets: defaultdict[tuple[int, int], list[Purchase]] = defaultdict(list)
+    for purchase in ordered:
+        ts = parse_timestamp(purchase.purchased_at)
+        buckets[(ts.year, ts.month)].append(purchase)
+
+    if not buckets:
+        return []
+
+    latest_bucket = max(buckets.keys())
+    return buckets[latest_bucket]
+
+
+def _softmax(scores: Sequence[float]) -> list[float]:
+    if not scores:
+        return []
+    shift = max(scores)
+    exponentials = [exp(score - shift) for score in scores]
+    total = sum(exponentials)
+    if total == 0:
+        return [0.0 for _ in scores]
+    return [value / total for value in exponentials]
+
+
+def predict_next_purchases(
+    purchases: Iterable[Purchase],
+    *,
+    profile: MemberProfile | None = None,
+    insights: PurchaseInsights | None = None,
+    limit: int = 7,
+) -> PredictionResult:
+    purchase_list = list(purchases)
+    window = get_previous_month_purchases(purchase_list)
+    if not window:
+        window = purchase_list
+
+    # Build frequency data.
+    category_counter: Counter[str] = Counter()
+    price_points: list[float] = []
+    for purchase in window:
+        category = infer_category_from_item(purchase.item)
+        category_counter[category] += 1
+        price_points.append(float(purchase.unit_price))
+
+    history_set = {purchase.item for purchase in purchase_list}
+    purchased_codes = purchased_product_codes(history_set)
+
+    total_category = sum(category_counter.values()) or 1
+    category_weight_map = {
+        category: count / total_category for category, count in category_counter.items()
+    }
+
+    recent_categories = [infer_category_from_item(p.item) for p in purchase_list[-5:]]
+    trend_weight: defaultdict[str, float] = defaultdict(float)
+    for index, category in enumerate(reversed(recent_categories), start=1):
+        trend_weight[category] += 1 / index
+    if trend_weight:
+        max_trend = max(trend_weight.values())
+    else:
+        max_trend = 1.0
+
+    average_price = sum(price_points) / len(price_points) if price_points else 1200.0
+
+    novelty_boost = 1.0 if profile and profile.mall_member_id else 0.8
+
+    catalogue = get_catalogue()
+    scored: list[tuple[float, Product]] = []
+    for product in catalogue:
+        if product.code in purchased_codes:
+            continue
+
+        cat_weight = category_weight_map.get(product.category, 0.15)
+        recency_bonus = trend_weight.get(product.category, 0.0) / max_trend
+        price_similarity = 1.0 - min(
+            abs(product.price - average_price) / max(product.price, average_price, 1.0),
+            1.0,
+        )
+        novelty = novelty_boost if product.name not in history_set else 0.3
+
+        score = (
+            0.45 * cat_weight
+            + 0.25 * recency_bonus
+            + 0.2 * price_similarity
+            + 0.1 * novelty
+        )
+        scored.append((score, product))
+
+    scored.sort(key=lambda entry: entry[0], reverse=True)
+    top_scored = scored[: limit * 2]
+    probabilities = _softmax([score for score, _ in top_scored])
+
+    results: list[PredictedItem] = []
+    for index, ((score, product), probability) in enumerate(zip(top_scored, probabilities)):
+        if len(results) >= limit:
+            break
+        adjusted_view_rate = product.view_rate * (0.9 + category_weight_map.get(product.category, 0.1))
+        adjusted_view_rate = min(1.0, adjusted_view_rate)
+        probability_percent = round(probability * 100, 1)
+        results.append(
+            PredictedItem(
+                product_code=product.code,
+                product_name=product.name,
+                category=product.category,
+                category_label=category_label(product.category),
+                price=product.price,
+                view_rate_percent=round(adjusted_view_rate * 100, 1),
+                probability=probability,
+                probability_percent=probability_percent,
+            )
+        )
+
+    # Build supporting data for the manager dashboard.
+    window_label = _format_window_label(window)
+    history = sorted(window, key=lambda p: parse_timestamp(p.purchased_at), reverse=True)
+    top_products = _summarise_top_products(window)
+    activities = _build_activity_feed(window, insights)
+
+    return PredictionResult(
+        items=results,
+        history=history,
+        top_products=top_products,
+        activities=activities,
+        window_label=window_label,
+    )
+
+
+def _format_window_label(window: Sequence[Purchase]) -> str:
+    if not window:
+        return "近期"
+    latest = parse_timestamp(window[-1].purchased_at)
+    return f"{latest.year} 年 {latest.month:02d} 月"
+
+
+def _summarise_top_products(purchases: Sequence[Purchase]) -> list[dict[str, object]]:
+    counter: Counter[str] = Counter()
+    revenue: defaultdict[str, float] = defaultdict(float)
+    for purchase in purchases:
+        counter[purchase.item] += float(purchase.quantity)
+        revenue[purchase.item] += float(purchase.total_price)
+    top_items = counter.most_common(3)
+    summary: list[dict[str, object]] = []
+    for name, quantity in top_items:
+        summary.append(
+            {
+                "item": name,
+                "quantity": quantity,
+                "total_price": round(revenue[name], 1),
+            }
+        )
+    return summary
+
+
+def _build_activity_feed(
+    purchases: Sequence[Purchase], insights: PurchaseInsights | None
+) -> list[dict[str, str]]:
+    if not purchases:
+        return []
+    latest_timestamp = parse_timestamp(purchases[-1].purchased_at)
+    categories = [infer_category_from_item(purchase.item) for purchase in purchases]
+    category_counts = Counter(categories)
+
+    templates = {
+        "fitness": "參與了會員健身互動課程，完成體能評估",
+        "dessert": "參加甜點試吃活動，留下高度滿意回饋",
+        "kindergarten": "參與親子共學日並關注幼兒成長課程",
+        "homemaker": "參與家居市集體驗新品居家用品",
+        "general": "逛遊生活選品快閃店，對永續主題最感興趣",
+    }
+
+    feed: list[dict[str, str]] = []
+    for category, count in category_counts.most_common(3):
+        description = templates.get(category, templates["general"])
+        feed.append(
+            {
+                "title": CATEGORY_LABELS.get(category, "生活選品"),
+                "description": description,
+                "timestamp": (latest_timestamp - timedelta(days=count)).strftime("%Y-%m-%d"),
+            }
+        )
+
+    if insights and insights.recommended_item:
+        feed.insert(
+            0,
+            {
+                "title": "AI 推薦",
+                "description": f"針對 {insights.recommended_item} 提供專屬回訪方案",
+                "timestamp": latest_timestamp.strftime("%Y-%m-%d"),
+            },
+        )
+
+    return feed[:3]

--- a/backend/static/ads/index.html
+++ b/backend/static/ads/index.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8" />
+  <title>廣告主視覺素材索引</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/static/css/ads.css" />
+  <style>
+    body{margin:0;background:#f8fafc;color:#0f172a;font-family:"Noto Sans TC","PingFang TC",sans-serif}
+    header{padding:2.5rem 1.5rem 1.25rem;text-align:center}
+    header h1{margin:0;font-size:2rem}
+    header p{margin:.5rem 0 0;color:#475569}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.5rem;padding:0 1.5rem 3rem}
+    .card{background:#fff;border-radius:1.25rem;overflow:hidden;box-shadow:0 15px 35px rgba(15,23,42,.1);display:flex;flex-direction:column}
+    .card img{width:100%;height:200px;object-fit:cover}
+    .card .meta{padding:1rem 1.25rem}
+    .card h2{margin:0 0 .25rem;font-size:1.25rem}
+    .card p{margin:.25rem 0;color:#475569;font-size:.95rem}
+    .card a{display:inline-block;margin-top:.75rem;color:#0f172a;text-decoration:none;font-weight:600}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>廣告主視覺素材索引</h1>
+    <p>所有連結皆為靜態資源，位於 <code>/static/images/ads/</code> 或其他對應目錄。</p>
+  </header>
+  <main class="grid">
+    <article class="card">
+      <img src="/static/images/ads/ME0000.jpg" alt="brand_new hero" />
+      <div class="meta">
+        <h2>ME0000.jpg</h2>
+        <p>情境：brand_new</p>
+        <a href="/static/images/ads/ME0000.jpg">下載圖片</a>
+      </div>
+    </article>
+    <article class="card">
+      <img src="/static/images/ads/ME0001.jpg" alt="registered dessert" />
+      <div class="meta">
+        <h2>ME0001.jpg</h2>
+        <p>情境：registered:dessert</p>
+        <a href="/static/images/ads/ME0001.jpg">下載圖片</a>
+      </div>
+    </article>
+    <article class="card">
+      <img src="/static/images/ads/ME0002.jpg" alt="registered kindergarten" />
+      <div class="meta">
+        <h2>ME0002.jpg</h2>
+        <p>情境：registered:kindergarten</p>
+        <a href="/static/images/ads/ME0002.jpg">下載圖片</a>
+      </div>
+    </article>
+    <article class="card">
+      <img src="/static/images/ads/ME0003.jpg" alt="registered fitness" />
+      <div class="meta">
+        <h2>ME0003.jpg</h2>
+        <p>情境：registered:fitness</p>
+        <a href="/static/images/ads/ME0003.jpg">下載圖片</a>
+      </div>
+    </article>
+    <article class="card">
+      <img src="/static/images/ads/AD0000.jpg" alt="unregistered fitness" />
+      <div class="meta">
+        <h2>AD0000.jpg</h2>
+        <p>情境：unregistered:fitness</p>
+        <a href="/static/images/ads/AD0000.jpg">下載圖片</a>
+      </div>
+    </article>
+    <article class="card">
+      <img src="/static/images/ads/AD0001.jpg" alt="unregistered homemaker" />
+      <div class="meta">
+        <h2>AD0001.jpg</h2>
+        <p>情境：unregistered:homemaker</p>
+        <a href="/static/images/ads/AD0001.jpg">下載圖片</a>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/backend/static/css/ads.css
+++ b/backend/static/css/ads.css
@@ -19,6 +19,7 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);
 .subtitle{margin:.25rem 0 1rem 0;opacity:.95;font-size:clamp(1.05rem,1.2vw+.6rem,1.35rem)}
 .bullets{margin:0 0 1.25rem 0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:.5rem 1rem}
 .bullets li{background:rgba(255,255,255,.12);padding:.35rem .6rem;border-radius:999px;border:1px solid rgba(255,255,255,.2);backdrop-filter:blur(4px)}
+.callout{margin:0 0 1.25rem 0;font-size:clamp(1.1rem,1.4vw+.6rem,1.45rem);font-weight:600;letter-spacing:.02em;opacity:.92}
 
 .btn{display:inline-block;padding:.7rem 1rem;border-radius:12px;text-decoration:none;background:#fff;
   color:#111;font-weight:700;box-shadow:var(--shadow)}

--- a/backend/static/css/manager.css
+++ b/backend/static/css/manager.css
@@ -1,0 +1,473 @@
+:root {
+  --bg: #0f172a;
+  --surface: rgba(15, 23, 42, 0.7);
+  --card: rgba(30, 41, 59, 0.85);
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.15);
+  --text: #f8fafc;
+  --muted: rgba(148, 163, 184, 0.9);
+  --border: rgba(148, 163, 184, 0.12);
+  font-family: "Inter", "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 45%, #020617 100%);
+  color: var(--text);
+  min-height: 100%;
+}
+
+body {
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.manager-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.manager-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.header-title h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-weight: 700;
+}
+
+.header-title p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  max-width: 640px;
+}
+
+.member-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  background: var(--card);
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+}
+
+.member-picker label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.member-picker select {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  padding: 0.65rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  min-width: 240px;
+}
+
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  margin-bottom: 1.5rem;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1.75rem;
+}
+
+.hero-card {
+  grid-column: span 12;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+  gap: 1.75rem;
+  background: var(--surface);
+  padding: 1.5rem;
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
+}
+
+.hero-image {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.4);
+  min-height: 260px;
+}
+
+.hero-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.hero-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.hero-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.hero-info h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.4vw, 2.2rem);
+}
+
+.member-profile {
+  margin: -0.5rem 0 0;
+  color: var(--muted);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.hero-stats div {
+  background: rgba(15, 23, 42, 0.45);
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+}
+
+.hero-stats dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.hero-stats dd {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.hero-links .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  background: var(--accent);
+  color: #0f172a;
+  border-radius: 14px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.15s ease;
+}
+
+.hero-links .btn:hover {
+  transform: translateY(-2px);
+}
+
+.hero-empty {
+  padding: 2.5rem 1.5rem;
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 18px;
+  border: 1px dashed var(--border);
+  text-align: center;
+  color: var(--muted);
+}
+
+.insights-card,
+.history-card,
+.member-card,
+.activities-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.5rem 1.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+}
+
+.insights-card {
+  grid-column: span 12;
+}
+
+.insights-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.insights-card h3,
+.history-card h3,
+.member-card h3,
+.activities-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.insights-card p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+.window-label {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 680px;
+}
+
+thead {
+  background: rgba(15, 23, 42, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 0.8rem;
+}
+
+thead th {
+  padding: 0.85rem;
+  text-align: left;
+  color: var(--muted);
+}
+
+tbody td {
+  padding: 0.85rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+tbody tr:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.top-products {
+  margin-top: 1.5rem;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  padding: 1rem 1.25rem;
+}
+
+.top-products h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.top-products ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.top-products li {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: var(--muted);
+}
+
+.history-card {
+  grid-column: span 6;
+}
+
+.history-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.history-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.4);
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+}
+
+.history-list strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.history-list span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.history-list time {
+  color: var(--muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.member-card {
+  grid-column: span 6;
+}
+
+.member-info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 1.25rem 0 0;
+}
+
+.member-info div {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 0.85rem 1rem;
+}
+
+.member-info dt {
+  margin: 0 0 0.25rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.member-info dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.activities-card {
+  grid-column: span 12;
+}
+
+.activity-list {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.activity-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.85rem;
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 1rem 1.2rem;
+}
+
+.activity-list strong {
+  font-size: 1.05rem;
+}
+
+.activity-list p {
+  margin: 0.4rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.activity-list time {
+  color: var(--muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.empty {
+  text-align: center;
+  padding: 1.5rem 0;
+  color: var(--muted);
+}
+
+@media (max-width: 1024px) {
+  .hero-card {
+    grid-template-columns: 1fr;
+  }
+
+  .history-card,
+  .member-card {
+    grid-column: span 12;
+  }
+}
+
+@media (max-width: 720px) {
+  .manager-shell {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .dashboard {
+    gap: 1.25rem;
+  }
+
+  .member-picker select {
+    min-width: unset;
+  }
+
+  table {
+    min-width: 520px;
+  }
+}

--- a/backend/templates/ad.html
+++ b/backend/templates/ad.html
@@ -7,9 +7,12 @@
   <!-- 每 5 秒刷新；可用 refresh_sec 覆蓋 -->
   <meta http-equiv="refresh" content="{{ refresh_sec|default(5) }}">
 
-  {# v2 才載入新版樣式（partial 使用的 CSS） #}
-  {% if request.args.get('v2') %}
-    <link rel="preload" as="image" href="{{ hero_image_url|default(url_for('static', filename='images/ads/ME0000.jpg')) }}">
+  {% set is_v2 = request.args.get('v2') == '1' %}
+  {% set hero_default = url_for('static', filename='images/ads/ME0000.jpg') %}
+  {% set hero_url = hero_image_url|default(hero_default) %}
+
+  {% if is_v2 %}
+    <link rel="preload" as="image" href="{{ hero_url }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/ads.css') }}">
   {% else %}
     {# 舊版樣式：沿用 Codex 的設計（不動你的既有行為） #}
@@ -45,7 +48,13 @@
 </head>
 <body>
 
-{% if request.args.get('v2') %}
+{% set context = context if context is defined else None %}
+{% set insights = context.insights if context and context.insights is defined else None %}
+{% set scenario = scenario_key|default(insights.scenario if insights and insights.scenario is defined else '') %}
+{% set hero_image_url = hero_url %}
+{% set scenario_key = scenario %}
+
+{% if is_v2 %}
   {# 新版樣式：partial（帶 debug 支援） #}
   {% set debug = (request.args.get('debug') == '1') %}
   {% include "partials/ad_hero.html" %}
@@ -54,11 +63,13 @@
   {# 舊版樣式（Codex 版）：保留 insight 卡片與歷史清單 #}
   <div class="banner">
     <div class="hero">
-      <img src="{{ hero_image_url|default(url_for('static', filename='images/ads/ME0000.jpg')) }}"
-           alt="廣告主視覺 {{ (scenario_key or (context.insights.scenario if context and context.insights is defined else '')) | default('') }}">
+      <img src="{{ hero_url }}"
+           alt="廣告主視覺 {{ scenario|default('') }}">
     </div>
 
-    <h1>{{ (context.headline if context and context.headline is defined else (copy.title if copy and copy.title is defined else "智慧零售廣告看板")) }}</h1>
+    {% set legacy_copy = copy if copy is defined and copy else None %}
+    {% set headline = context.headline if context and context.headline is defined else (legacy_copy.title if legacy_copy and legacy_copy.title is defined else "智慧零售廣告看板") %}
+    <h1>{{ headline }}</h1>
 
     <div class="member-code">
       {% if context and context.member_code %}
@@ -69,27 +80,32 @@
     </div>
 
     <div class="subheading">
-      {{ (context.subheading if context and context.subheading is defined else (copy.subtitle if copy and copy.subtitle is defined else "")) }}
+      {% set subheading = context.subheading if context and context.subheading is defined else (legacy_copy.subtitle if legacy_copy and legacy_copy.subtitle is defined else "") %}
+      {{ subheading }}
     </div>
 
     <div class="highlight">
-      {{ (context.highlight if context and context.highlight is defined
-          else (copy.bullets|default(["入會禮","生日禮","點數回饋"])|join(" · "))) }}
+      {% set highlight_text = context.highlight if context and context.highlight is defined else None %}
+      {% if highlight_text %}
+        {{ highlight_text }}
+      {% else %}
+        {% set bullets = legacy_copy.bullets if legacy_copy and legacy_copy.bullets is defined and legacy_copy.bullets else ["入會禮","生日禮","點數回饋"] %}
+        {{ bullets|join(" · ") }}
+      {% endif %}
     </div>
 
     <div class="insight-card">
-      {% set scenario = (context.insights.scenario if context and context.insights is defined and context.insights.scenario is defined else scenario_key|default('')) %}
       {% if scenario == 'brand_new' %}
         <span class="badge">新客偵測</span>
         <p>第一次來店，尚未累積消費紀錄，立即推播加入會員與公版歡迎廣告。</p>
         <p>完成註冊即可領取開卡禮，並於現場啟用專屬折扣。</p>
       {% elif scenario == 'repeat_purchase' %}
         <span class="badge">回購洞察</span>
-        <p>近期 {{ context.insights.repeat_count if context and context.insights is defined and context.insights.repeat_count is defined else "多次" }} 次都選擇「{{ context.insights.recommended_item if context and context.insights is defined and context.insights.recommended_item is defined else "熱門品項" }}」，系統自動生成此商品的個人化推播。</p>
+        <p>近期 {{ insights.repeat_count if insights and insights.repeat_count is defined else "多次" }} 次都選擇「{{ insights.recommended_item if insights and insights.recommended_item is defined else "熱門品項" }}」，系統自動生成此商品的個人化推播。</p>
         <p>建議同步展示加價購組合或升級方案，提高客單價。</p>
       {% else %}
         <span class="badge">老會員預測</span>
-        <p>根據歷史消費，AI 預估再次購買「{{ context.insights.recommended_item if context and context.insights is defined and context.insights.recommended_item is defined else "偏好品項" }}」的機率約 {{ context.insights.probability_percent if context and context.insights is defined and context.insights.probability_percent is defined else "—" }}。</p>
+        <p>根據歷史消費，AI 預估再次購買「{{ insights.recommended_item if insights and insights.recommended_item is defined else "偏好品項" }}」的機率約 {{ insights.probability_percent if insights and insights.probability_percent is defined else "—" }}。</p>
         <p>推播會員專屬優惠，並提醒可於收銀台加碼點數。</p>
       {% endif %}
     </div>

--- a/backend/templates/manager.html
+++ b/backend/templates/manager.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>智慧廣告管理後台</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/manager.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div class="manager-shell">
+      <header class="manager-header">
+        <div class="header-title">
+          <h1>ESP32-CAM 智慧廣告中控台</h1>
+          <p>依據上一期的消費紀錄，自動推估本月潛在購買清單與專屬廣告資源</p>
+        </div>
+        <form class="member-picker" method="get">
+          <label for="member_id">選擇顧客</label>
+          <div class="picker-input">
+            <select id="member_id" name="member_id" onchange="this.form.submit()">
+              {% if members %}
+                {% for profile in members %}
+                  <option value="{{ profile.member_id }}" {% if context and profile.member_id == context.member_id %}selected{% elif not context and profile.member_id == request.args.get('member_id') %}selected{% endif %}>
+                    {{ profile.mall_member_id or profile.member_id }} · {{ profile.profile_label|replace('-', ' ') }}
+                  </option>
+                {% endfor %}
+              {% else %}
+                <option value="" selected>尚無會員資料</option>
+              {% endif %}
+            </select>
+            <noscript><button type="submit">載入</button></noscript>
+          </div>
+        </form>
+      </header>
+
+      {% if error %}
+        <div class="alert">
+          {{ error }}
+        </div>
+      {% endif %}
+
+      <main class="dashboard">
+        <section class="hero-card">
+          <div class="hero-image">
+            {% if context and context.hero_image_url %}
+              <img src="{{ context.hero_image_url }}" alt="顧客影像" loading="lazy">
+            {% else %}
+              <div class="hero-placeholder">等待上傳 ESP32-CAM 圖像</div>
+            {% endif %}
+          </div>
+          <div class="hero-info">
+            {% if context %}
+              {% set member_profile = context.member %}
+              {% set display_name = member_profile.mall_member_id if member_profile and member_profile.mall_member_id else (member_profile.member_id if member_profile and member_profile.member_id else context.member_id) %}
+              <div class="hero-meta">
+                <span class="tag scenario">情境：{{ context.scenario_key }}</span>
+                <span class="tag window">分析區間：{{ context.prediction.window_label }}</span>
+              </div>
+              <h2>{{ display_name or '未知顧客' }}</h2>
+              <p class="member-profile">{{ member_profile.profile_label|replace('-', ' ') if member_profile else '尚未辨識' }}</p>
+              <dl class="hero-stats">
+                <div>
+                  <dt>核心主打</dt>
+                  <dd>{{ context.analysis.recommended_item or '等待歷史累積' }}</dd>
+                </div>
+                <div>
+                  <dt>預估轉換率</dt>
+                  <dd>{{ context.analysis.probability_percent }}%</dd>
+                </div>
+                <div>
+                  <dt>歷史訂單數</dt>
+                  <dd>{{ context.analysis.total_purchases }}</dd>
+                </div>
+              </dl>
+              <div class="hero-links">
+                <a class="btn" href="{{ context.ad_url }}" target="_blank" rel="noopener">前往顧客版廣告</a>
+              </div>
+            {% else %}
+              <div class="hero-empty">請先選擇顧客，即可載入預測資訊</div>
+            {% endif %}
+          </div>
+        </section>
+
+        <section class="insights-card">
+          <header>
+            <div>
+              <h3>本月潛在熱銷清單</h3>
+              <p>依據上一個月的消費紀錄推估尚未購買的商品，並計算購買機率</p>
+            </div>
+            {% if context %}
+              <span class="window-label">分析窗口：{{ context.prediction.window_label }}</span>
+            {% endif %}
+          </header>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>商品編號</th>
+                  <th>商品名稱</th>
+                  <th>商品類別</th>
+                  <th>商品價格</th>
+                  <th>商品查閱率</th>
+                  <th>預估購買機率</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% if context and context.prediction.items %}
+                  {% for item in context.prediction.items %}
+                    <tr>
+                      <td>{{ item.product_code }}</td>
+                      <td>{{ item.product_name }}</td>
+                      <td>{{ item.category_label }}</td>
+                      <td>NT$ {{ '%.0f'|format(item.price) }}</td>
+                      <td>{{ '%.1f'|format(item.view_rate_percent) }}%</td>
+                      <td>{{ '%.1f'|format(item.probability_percent) }}%</td>
+                    </tr>
+                  {% endfor %}
+                {% else %}
+                  <tr>
+                    <td colspan="6" class="empty">尚無可用預測資料</td>
+                  </tr>
+                {% endif %}
+              </tbody>
+            </table>
+          </div>
+          {% if context and context.prediction.top_products %}
+            <div class="top-products">
+              <h4>上一期熱銷前三名</h4>
+              <ul>
+                {% for product in context.prediction.top_products %}
+                  <li>
+                    <strong>{{ product.item }}</strong>
+                    <span>數量 {{ product.quantity }}</span>
+                    <span>金額 NT$ {{ '%.0f'|format(product.total_price) }}</span>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+        </section>
+
+        <section class="history-card">
+          <header>
+            <h3>上一個月消費紀錄</h3>
+            {% if context %}
+              <span>{{ context.prediction.window_label }}</span>
+            {% endif %}
+          </header>
+          {% if context and context.prediction.history %}
+            <ul class="history-list">
+              {% for purchase in context.prediction.history %}
+                <li>
+                  <div>
+                    <strong>{{ purchase.item }}</strong>
+                    <span>數量 {{ '%.0f'|format(purchase.quantity) }} · 單價 NT$ {{ '%.0f'|format(purchase.unit_price) }}</span>
+                  </div>
+                  <time>{{ purchase.purchased_at }}</time>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="empty">尚無上一個月的消費資料</p>
+          {% endif %}
+        </section>
+
+        <section class="member-card">
+          <header>
+            <h3>會員資料</h3>
+          </header>
+          {% if context and context.member %}
+            <dl class="member-info">
+              <div>
+                <dt>會員編號</dt>
+                <dd>{{ context.member.mall_member_id or '尚未加入會員' }}</dd>
+              </div>
+              <div>
+                <dt>會員狀態</dt>
+                <dd>{{ context.member.member_status }}</dd>
+              </div>
+              <div>
+                <dt>加入日期</dt>
+                <dd>{{ context.member.joined_at }}</dd>
+              </div>
+              <div>
+                <dt>職業 / 產業別</dt>
+                <dd>{{ context.member.occupation or '—' }}</dd>
+              </div>
+              <div>
+                <dt>聯絡電話</dt>
+                <dd>{{ context.member.phone }}</dd>
+              </div>
+              <div>
+                <dt>電子郵件</dt>
+                <dd>{{ context.member.email }}</dd>
+              </div>
+              <div>
+                <dt>郵遞地址</dt>
+                <dd>{{ context.member.address or '—' }}</dd>
+              </div>
+              <div>
+                <dt>點數餘額</dt>
+                <dd>{{ '%.0f'|format(context.member.points_balance) }}</dd>
+              </div>
+            </dl>
+          {% else %}
+            <p class="empty">尚無會員資料</p>
+          {% endif %}
+        </section>
+
+        <section class="activities-card">
+          <header>
+            <h3>參與活動紀錄</h3>
+          </header>
+          {% if context and context.prediction.activities %}
+            <ul class="activity-list">
+              {% for activity in context.prediction.activities %}
+                <li>
+                  <div>
+                    <strong>{{ activity.title }}</strong>
+                    <p>{{ activity.description }}</p>
+                  </div>
+                  <time>{{ activity.timestamp }}</time>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="empty">尚無參與活動紀錄</p>
+          {% endif %}
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/backend/templates/partials/ad_hero.html
+++ b/backend/templates/partials/ad_hero.html
@@ -1,16 +1,36 @@
 <!-- backend/templates/partials/ad_hero.html -->
+{% set hero_url = hero_image_url|default(url_for('static', filename='images/ads/ME0000.jpg')) %}
+{% set ad_context = context if context is defined and context else None %}
+{% set copy_source = copy if copy is defined and copy else None %}
+{% set cta_source = cta if cta is defined and cta else None %}
+{% set scenario_value = scenario_key|default('brand_new') %}
+
+{% set title = copy_source.title if copy_source and copy_source.title is defined else (ad_context.headline if ad_context and ad_context.headline is defined else "歡迎光臨！加入會員賺好禮") %}
+{% set subtitle = copy_source.subtitle if copy_source and copy_source.subtitle is defined else (ad_context.subheading if ad_context and ad_context.subheading is defined else "新朋友限定，立即入會享專屬優惠") %}
+{% set highlight_text = ad_context.highlight if ad_context and ad_context.highlight is defined else (copy_source.highlight if copy_source and copy_source.highlight is defined else None) %}
+{% set bullet_source = copy_source.bullets if copy_source and copy_source.bullets is defined and copy_source.bullets else None %}
+{% if not bullet_source and highlight_text %}
+  {% set bullet_source = [highlight_text] %}
+{% endif %}
+{% set bullets = bullet_source if bullet_source else ["入會禮", "生日禮", "點數回饋"] %}
+{% set callout = highlight_text if highlight_text and bullets != [highlight_text] else None %}
+
+{% set inferred_cta_type = cta_source.type if cta_source and cta_source.type is defined else ("join" if scenario_value in ["brand_new", "unregistered:fitness", "unregistered:homemaker"] else "none") %}
+{% set cta_label = cta_source.label if cta_source and cta_source.label is defined else ("立即加入會員" if inferred_cta_type == "join" else "前往選購") %}
+{% set cta_href = cta_source.href if cta_source and cta_source.href is defined else "#" %}
+
 <section class="ad-hero">
   {% if debug|default(false) %}
   <div class="debug-bar">
     <strong>DEBUG</strong>
-    <span>scenario_key: {{ scenario_key|default("brand_new") }}</span>
-    <span>hero_image_url: {{ hero_image_url|default(url_for('static', filename='images/ads/ME0000.jpg')) }}</span>
+    <span>scenario_key: {{ scenario_value }}</span>
+    <span>hero_image_url: {{ hero_url }}</span>
   </div>
   {% endif %}
 
   <div class="hero">
     <img
-      src="{{ hero_image_url|default(url_for('static', filename='images/ads/ME0000.jpg')) }}"
+      src="{{ hero_url }}"
       alt="ad-hero"
       class="hero-img"
       loading="eager"
@@ -19,19 +39,21 @@
     <div class="hero-overlay"></div>
 
     <div class="copy">
-      <h1 class="title">{{ copy.title|default("歡迎光臨！加入會員賺好禮") }}</h1>
-      <p class="subtitle">{{ copy.subtitle|default("新朋友限定，立即入會享專屬優惠") }}</p>
+      <h1 class="title">{{ title }}</h1>
+      <p class="subtitle">{{ subtitle }}</p>
 
-      {% set bullets = copy.bullets if copy and copy.bullets is defined and copy.bullets else ["入會禮","生日禮","點數回饋"] %}
       <ul class="bullets">
         {% for b in bullets %}<li>• {{ b }}</li>{% endfor %}
       </ul>
 
-      {% set cta_type = cta.type if cta and cta.type is defined else ("join" if scenario_key|default("brand_new") in ["brand_new","unregistered:fitness","unregistered:homemaker"] else "none") %}
-      {% if cta_type == "join" %}
-        <a class="btn btn-primary" href="{{ cta.href|default('#') }}">{{ cta.label|default("立即加入會員") }}</a>
-      {% elif cta_type == "shop" %}
-        <a class="btn" href="{{ cta.href|default('#') }}">{{ cta.label|default("前往選購") }}</a>
+      {% if callout %}
+        <p class="callout">{{ callout }}</p>
+      {% endif %}
+
+      {% if inferred_cta_type == "join" %}
+        <a class="btn btn-primary" href="{{ cta_href }}">{{ cta_label }}</a>
+      {% elif inferred_cta_type == "shop" %}
+        <a class="btn" href="{{ cta_href }}">{{ cta_label }}</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a central product catalogue and prediction helper to turn last month's purchases into seven ranked recommendations
- expose a manager dashboard view backed by the new prediction module, including hero image resolution and contextual data
- document the item code scheme, probability formula, and verification steps while styling the dashboard to match the provided layout

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68dbebe2d828832e98f30f759e94c39e