### PR TITLE
Add member profile names to database schema

### DIFF
--- a/backend/data/mvp.sql
+++ b/backend/data/mvp.sql
@@ -2,6 +2,7 @@ BEGIN TRANSACTION;
 CREATE TABLE member_profiles (
                     profile_id INTEGER PRIMARY KEY AUTOINCREMENT,
                     profile_label TEXT NOT NULL UNIQUE,
+                    name TEXT,
                     member_id TEXT UNIQUE,
                     mall_member_id TEXT,
                     member_status TEXT DEFAULT '有效',
@@ -16,11 +17,11 @@ CREATE TABLE member_profiles (
                     first_image_filename TEXT,
                     FOREIGN KEY(member_id) REFERENCES members(member_id)
                 );
-INSERT INTO "member_profiles" VALUES(1,'dessert-lover','MEME0383FE3AA','ME0001','有效','2021-06-12',1520.0,'女','1988-07-12','0912-345-678','dessertlover@example.com','台北市信義區松壽路10號','甜點教室講師',NULL);
-INSERT INTO "member_profiles" VALUES(2,'family-groceries','MEM692FFD0824','ME0002','有效','2020-09-01',980.0,'女','1990-02-08','0923-556-789','familybuyer@example.com','新北市板橋區文化路100號','幼兒園老師',NULL);
-INSERT INTO "member_profiles" VALUES(3,'fitness-enthusiast','MEMFITNESS2025','ME0003','有效','2019-11-20',2040.0,'男','1985-04-19','0955-112-233','fitgoer@example.com','台中市西屯區市政北二路88號','企業健身顧問',NULL);
-INSERT INTO "member_profiles" VALUES(4,'home-manager','MEMHOMECARE2025','',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
-INSERT INTO "member_profiles" VALUES(5,'wellness-gourmet','MEMHEALTH2025','',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
+INSERT INTO "member_profiles" VALUES(1,'dessert-lover','林悅心','MEME0383FE3AA','ME0001','有效','2021-06-12',1520.0,'女','1988-07-12','0912-345-678','dessertlover@example.com','台北市信義區松壽路10號','甜點教室講師',NULL);
+INSERT INTO "member_profiles" VALUES(2,'family-groceries','陳雅雯','MEM692FFD0824','ME0002','有效','2020-09-01',980.0,'女','1990-02-08','0923-556-789','familybuyer@example.com','新北市板橋區文化路100號','幼兒園老師',NULL);
+INSERT INTO "member_profiles" VALUES(3,'fitness-enthusiast','張智翔','MEMFITNESS2025','ME0003','有效','2019-11-20',2040.0,'男','1985-04-19','0955-112-233','fitgoer@example.com','台中市西屯區市政北二路88號','企業健身顧問',NULL);
+INSERT INTO "member_profiles" VALUES(4,'home-manager','黃珮真','MEMHOMECARE2025','',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
+INSERT INTO "member_profiles" VALUES(5,'wellness-gourmet','吳品蓉','MEMHEALTH2025','',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
 CREATE TABLE members (
                     member_id TEXT PRIMARY KEY,
                     encoding_json TEXT NOT NULL

--- a/backend/database.py
+++ b/backend/database.py
@@ -54,6 +54,7 @@ class Purchase:
 class MemberProfile:
     profile_id: int
     profile_label: str
+    name: str | None
     member_id: str | None
     mall_member_id: str | None
     member_status: str | None
@@ -189,6 +190,7 @@ class Database:
             expected_profile_columns = [
                 "profile_id",
                 "profile_label",
+                "name",
                 "member_id",
                 "mall_member_id",
                 "member_status",
@@ -215,6 +217,7 @@ class Database:
                         "gender",
                         "phone",
                         "email",
+                        "name",
                     }
                     if any(row["name"] in nullable_columns and row["notnull"] for row in profile_meta):
                         conn.execute("DROP TABLE IF EXISTS member_profiles")
@@ -224,6 +227,7 @@ class Database:
                 CREATE TABLE IF NOT EXISTS member_profiles (
                     profile_id INTEGER PRIMARY KEY AUTOINCREMENT,
                     profile_label TEXT NOT NULL UNIQUE,
+                    name TEXT,
                     member_id TEXT UNIQUE,
                     mall_member_id TEXT,
                     member_status TEXT DEFAULT '有效',
@@ -551,6 +555,7 @@ class Database:
                 """
                 SELECT profile_id,
                        profile_label,
+                       name,
                        member_id,
                        mall_member_id,
                        member_status,
@@ -575,6 +580,7 @@ class Database:
         return MemberProfile(
             profile_id=int(row["profile_id"]),
             profile_label=str(row["profile_label"]),
+            name=str(row["name"]) if row["name"] else None,
             member_id=str(row["member_id"]) if row["member_id"] else None,
             mall_member_id=str(row["mall_member_id"]) if row["mall_member_id"] else None,
             member_status=str(row["member_status"]) if row["member_status"] else None,
@@ -597,6 +603,7 @@ class Database:
                 """
                 SELECT profile_id,
                        profile_label,
+                       name,
                        member_id,
                        mall_member_id,
                        member_status,
@@ -620,6 +627,7 @@ class Database:
                 MemberProfile(
                     profile_id=int(row["profile_id"]),
                     profile_label=str(row["profile_label"]),
+                    name=str(row["name"]) if row["name"] else None,
                     member_id=str(row["member_id"]) if row["member_id"] else None,
                     mall_member_id=str(row["mall_member_id"]) if row["mall_member_id"] else None,
                     member_status=str(row["member_status"]) if row["member_status"] else None,
@@ -1228,6 +1236,7 @@ class Database:
 
         self._seed_member_profile(
             profile_label="dessert-lover",
+            name="林悅心",
             member_id=None,
             mall_member_id="ME0001",
             member_status="有效",
@@ -1242,6 +1251,7 @@ class Database:
         )
         self._seed_member_profile(
             profile_label="family-groceries",
+            name="陳雅雯",
             member_id=None,
             mall_member_id="ME0002",
             member_status="有效",
@@ -1256,6 +1266,7 @@ class Database:
         )
         self._seed_member_profile(
             profile_label="fitness-enthusiast",
+            name="張智翔",
             member_id=None,
             mall_member_id="ME0003",
             member_status="有效",
@@ -1270,6 +1281,7 @@ class Database:
         )
         self._seed_member_profile(
             profile_label="home-manager",
+            name="黃珮真",
             member_id=None,
             mall_member_id="",
             member_status=None,
@@ -1284,6 +1296,7 @@ class Database:
         )
         self._seed_member_profile(
             profile_label="wellness-gourmet",
+            name="吳品蓉",
             member_id=None,
             mall_member_id="",
             member_status=None,
@@ -1331,6 +1344,7 @@ class Database:
         self,
         *,
         profile_label: str,
+        name: str | None,
         member_id: str | None,
         mall_member_id: str | None,
         member_status: str | None,
@@ -1351,6 +1365,7 @@ class Database:
             ).fetchone()
 
             params = (
+                name,
                 member_id,
                 mall_member_id,
                 member_status,
@@ -1369,6 +1384,7 @@ class Database:
                     """
                     INSERT INTO member_profiles (
                         profile_label,
+                        name,
                         member_id,
                         mall_member_id,
                         member_status,
@@ -1381,7 +1397,7 @@ class Database:
                         address,
                         occupation
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (profile_label, *params),
                 )
@@ -1389,7 +1405,8 @@ class Database:
                 conn.execute(
                     """
                     UPDATE member_profiles
-                    SET member_id = ?,
+                    SET name = ?,
+                        member_id = ?,
                         mall_member_id = ?,
                         member_status = ?,
                         joined_at = ?,


### PR DESCRIPTION
## Summary
- add an optional `name` column to the member profile schema and dataclass
- update profile queries and seed helpers to read/write the new field and populate persona names
- align the SQL seed data with the updated schema

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68dcd036ef308322a32320bec8562c07