### PR TITLE
Use member names across dashboards

### DIFF
--- a/backend/templates/dashboard.html
+++ b/backend/templates/dashboard.html
@@ -30,11 +30,11 @@
             <h2 class="hide">顧客資料</h2>
             <figure class="customer-photo {% if not profile_image_url %}placeholder{% endif %}">
                 {% set fallback_photo = url_for('static', filename='images/face.jpg') %}
-                <img src="{{ profile_image_url or fallback_photo }}" alt="{{ persona_name or profile.profile_label or '會員' }} 的照片">
+                <img src="{{ profile_image_url or fallback_photo }}" alt="{{ display_name }} 的照片">
             </figure>
             <section class="customer-infolist">
                 <ul class="customer-basic-info">
-                    <li class="customer-name">{{ persona_name or profile.profile_label or '尚未命名會員' }}</li>
+                    <li class="customer-name">{{ display_name }}</li>
                     {% set membership_status = profile.member_status or '尚未提供' %}
                     <li class="customer-level {% if membership_status == '有效' %}general{% endif %}">{{ membership_status }}</li>
                     <li>Face ID：{{ profile.member_id or '尚未指派' }}</li>
@@ -65,7 +65,9 @@
             <section id="customer-tags">
                 <h2>顧客標籤</h2>
                 <ul class="customer-taglist">
-                    <li>#甜點收藏家</li>
+                    {% if persona_label %}
+                    <li>#{{ persona_label }}</li>
+                    {% endif %}
                     <li>#健身族群</li>
                     <li>#保健食品</li>
                     <li>#蛋白粉</li>

--- a/backend/templates/latest_upload.html
+++ b/backend/templates/latest_upload.html
@@ -114,6 +114,12 @@
             <dd>{{ event.created_at }}</dd>
             <dt>辨識結果</dt>
             <dd>會員代號：{{ event.member_code }}（ID：{{ event.member_id }}）</dd>
+            <dt>會員姓名</dt>
+            <dd>{{ display_name }}</dd>
+            {% if persona_label %}
+            <dt>Persona 標籤</dt>
+            <dd>{{ persona_label }}</dd>
+            {% endif %}
             <dt>廣告頁面</dt>
             <dd><a class="button" href="{{ ad_url }}" target="_blank" rel="noopener">開啟個人化廣告頁</a></dd>
             <dt>會員資料</dt>

--- a/backend/templates/members.html
+++ b/backend/templates/members.html
@@ -43,6 +43,11 @@
         font-size: 1.5rem;
         color: #1f4e79;
       }
+      .member-card h2 .persona-label {
+        font-size: 0.95rem;
+        color: #6c757d;
+        margin-left: 0.5rem;
+      }
       .member-meta {
         display: grid;
         grid-template-columns: minmax(180px, 220px) 1fr;
@@ -161,13 +166,6 @@
       <a class="back-link" href="{{ url_for('latest_upload_dashboard') }}">← 返回最新上傳影像儀表板</a>
     </header>
     <main>
-      {% set label_map = {
-        'dessert-lover': '甜點收藏家',
-        'family-groceries': '幼兒園家長',
-        'fitness-enthusiast': '健身族',
-        'home-manager': '家庭主婦',
-        'wellness-gourmet': '健康食品愛好者'
-      } %}
       {% if not members %}
         <div class="member-card">
           <p class="empty-message">目前沒有可顯示的會員資料。</p>
@@ -176,10 +174,13 @@
         {% for entry in members %}
           {% set profile = entry.profile %}
           {% set purchases = entry.purchases %}
+          {% set persona_label = entry.persona_label %}
           <section class="member-card">
-            {% set persona_name = label_map.get(profile.profile_label, profile.profile_label | replace('-', ' ') | title) %}
             <h2>
-              {{ persona_name }}
+              {{ entry.display_name }}
+              {% if persona_label %}
+                <span class="persona-label">· {{ persona_label }}</span>
+              {% endif %}
               {% if profile.mall_member_id %}
                 <small>（商場會員代號：{{ profile.mall_member_id }}）</small>
               {% else %}
@@ -189,7 +190,7 @@
             <div class="member-meta">
               <div class="member-photo {% if not profile.first_image_filename %}placeholder{% endif %}">
                 {% if profile.first_image_filename %}
-                  <img src="{{ url_for('serve_upload_image', filename=profile.first_image_filename) }}" alt="{{ profile.member_id or '尚未指派' }} 首次辨識影像">
+                  <img src="{{ url_for('serve_upload_image', filename=profile.first_image_filename) }}" alt="{{ entry.display_name }} 首次辨識影像">
                   <span class="caption">首次辨識影像</span>
                 {% else %}
                   <span>尚未留存首次辨識影像</span>


### PR DESCRIPTION
## Summary
- prefer each member profile's name in dashboard, latest upload, and directory views while falling back to persona labels only when necessary
- centralize persona label lookups for reuse in tags and member metadata

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcd3bfe44c8322873c7d4c59bec9a9