### PR TITLE
Add /ad/latest/stream SSE endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ firmware/esp32cam_mvp/  # ESP32-CAM PlatformIO 專案
 
     - `POST /upload_face`：接受 `image/jpeg` 或 `multipart/form-data` 影像。回傳 JSON，內含 `member_id`、`member_code`（僅在已有商場註冊代號時帶值）、`new_member` 旗標與廣告頁 URL。
     - `GET /ad/<member_id>`：根據 SQLite + Gemini Text 的輸出生成廣告頁，內建 `<meta http-equiv="refresh" content="5">`，適合放在電視棒上自動輪播。
+    - `GET /ad/latest/stream`：透過 Server-Sent Events 形式推送最新的上傳事件與廣告頁連結，前端或電視棒可直接串流更新。若僅需單次查詢，可加上 `?once=1` 取得最新事件後立即結束連線。
     - `GET /latest_upload`：顯示最新上傳影像、辨識結果、個人化廣告連結與各階段耗時分析，方便除錯與現場展示。後端會保留最新一張上傳影像，並為每位會員留存首次辨識的照片，以避免佔用過多空間又能在名單頁回溯影像。
     - `GET /members`：瀏覽預寫會員的個人資料、首次辨識影像與 2025 年消費紀錄，也可從最新上傳儀表板的「會員資料」按鈕快速進入。
     - `POST /adgen`：呼叫 Vertex AI Gemini + Imagen 生成標題、副標、CTA 與海報圖。

--- a/tests/test_latest_stream.py
+++ b/tests/test_latest_stream.py
@@ -1,0 +1,134 @@
+import json
+import sys
+import types
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# ---------------------------------------------------------------------------
+# Stub cloud SDKs that are unavailable in the execution environment.
+# ---------------------------------------------------------------------------
+google_stub = types.ModuleType("google")
+cloud_stub = types.ModuleType("google.cloud")
+storage_stub = types.ModuleType("google.cloud.storage")
+aiplatform_stub = types.ModuleType("google.cloud.aiplatform")
+api_core_stub = types.ModuleType("google.api_core")
+api_core_exceptions_stub = types.ModuleType("google.api_core.exceptions")
+vertexai_stub = types.ModuleType("vertexai")
+vertexai_generative_stub = types.ModuleType("vertexai.generative_models")
+vertexai_preview_stub = types.ModuleType("vertexai.preview")
+vertexai_preview_vision_stub = types.ModuleType("vertexai.preview.vision_models")
+vertexai_vision_stub = types.ModuleType("vertexai.vision_models")
+
+
+class _StorageClient:  # pragma: no cover - just a safety stub
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("google.cloud.storage is not available in tests")
+
+
+def _noop(*_args, **_kwargs):  # pragma: no cover
+    return None
+
+
+class _GenerativeModel:  # pragma: no cover - simple stub
+    def __init__(self, name: str):
+        self._name = name
+
+    def generate_content(self, parts, request_options=None):
+        return types.SimpleNamespace(text="")
+
+
+class _Part:  # pragma: no cover
+    @classmethod
+    def from_data(cls, **kwargs):
+        return kwargs
+
+
+class _GenerationConfig:  # pragma: no cover
+    def __init__(self, **kwargs):
+        self.values = kwargs
+
+
+class _ImageGenerationModel:  # pragma: no cover
+    @classmethod
+    def from_pretrained(cls, name: str):
+        return cls()
+
+
+storage_stub.Client = _StorageClient
+cloud_stub.storage = storage_stub
+cloud_stub.aiplatform = aiplatform_stub
+api_core_exceptions_stub.NotFound = type("NotFound", (Exception,), {})
+api_core_stub.exceptions = api_core_exceptions_stub
+vertexai_generative_stub.GenerativeModel = _GenerativeModel
+vertexai_generative_stub.Part = _Part
+vertexai_preview_vision_stub.ImageGenerationModel = _ImageGenerationModel
+vertexai_vision_stub.ImageGenerationModel = _ImageGenerationModel
+vertexai_preview_stub.vision_models = vertexai_preview_vision_stub
+vertexai_generative_stub.GenerationConfig = _GenerationConfig
+vertexai_stub.generative_models = vertexai_generative_stub
+vertexai_stub.preview = vertexai_preview_stub
+vertexai_stub.vision_models = vertexai_vision_stub
+
+aiplatform_stub.init = _noop
+
+google_stub.cloud = cloud_stub
+
+sys.modules.setdefault("google", google_stub)
+sys.modules.setdefault("google.cloud", cloud_stub)
+sys.modules.setdefault("google.cloud.storage", storage_stub)
+sys.modules.setdefault("google.cloud.aiplatform", aiplatform_stub)
+sys.modules.setdefault("google.api_core", api_core_stub)
+sys.modules.setdefault("google.api_core.exceptions", api_core_exceptions_stub)
+sys.modules.setdefault("vertexai", vertexai_stub)
+sys.modules.setdefault("vertexai.generative_models", vertexai_generative_stub)
+sys.modules.setdefault("vertexai.preview", vertexai_preview_stub)
+sys.modules.setdefault("vertexai.preview.vision_models", vertexai_preview_vision_stub)
+sys.modules.setdefault("vertexai.vision_models", vertexai_vision_stub)
+
+from backend.app import app, database
+
+
+@pytest.fixture()
+def client():
+    app.config["TESTING"] = True
+    database.cleanup_upload_events(keep_latest=0)
+    with app.test_client() as test_client:
+        yield test_client
+    database.cleanup_upload_events(keep_latest=0)
+
+
+def _parse_sse_payload(body: str) -> dict:
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[len("data: ") :])
+    raise AssertionError("SSE payload did not contain data line")
+
+
+def test_latest_stream_emits_latest_event(client):
+    member_id = f"MEM{uuid4().hex[:8]}"
+    database.record_upload_event(
+        member_id=member_id,
+        image_filename=None,
+        upload_duration=0.11,
+        recognition_duration=0.22,
+        ad_duration=0.33,
+        total_duration=0.66,
+    )
+
+    response = client.get("/ad/latest/stream?once=1")
+    body = b"".join(response.response).decode("utf-8")
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/event-stream")
+
+    payload = _parse_sse_payload(body)
+    assert payload["status"] == "ok"
+    assert payload["member_id"] == member_id
+    assert payload["ad_url"].endswith(f"/ad/{member_id}")
+    assert payload["event_id"] == database.get_latest_upload_event().id


### PR DESCRIPTION
## Summary
- add a server-sent events feed at `/ad/latest/stream` that streams the latest upload metadata and ad URL
- document the new streaming endpoint for integrators in the README
- cover the endpoint with a pytest that stubs unavailable cloud SDK dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dce7fb1eb0832287e80c2982b12172