### PR TITLE
Handle invalid interval query in latest ad stream

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -304,7 +304,12 @@ def render_ad(member_id: str):
 def latest_ad_stream() -> Response:
     """Server-Sent Events feed with the most recent personalised ad metadata."""
 
-    poll_interval = float(request.args.get("interval", 2.0))
+    interval_arg = request.args.get("interval", "2.0")
+    try:
+        poll_interval = float(interval_arg)
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid interval"}), 400
+
     poll_interval = max(0.5, min(10.0, poll_interval))
     send_once = request.args.get("once", "0") == "1"
     last_event_id = request.headers.get("Last-Event-ID") or request.args.get("lastEventId")

--- a/tests/test_latest_stream.py
+++ b/tests/test_latest_stream.py
@@ -132,3 +132,11 @@ def test_latest_stream_emits_latest_event(client):
     assert payload["member_id"] == member_id
     assert payload["ad_url"].endswith(f"/ad/{member_id}")
     assert payload["event_id"] == database.get_latest_upload_event().id
+
+
+def test_latest_stream_rejects_invalid_interval(client):
+    response = client.get("/ad/latest/stream?interval=abc&once=1")
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload == {"error": "Invalid interval"}


### PR DESCRIPTION
## Summary
- validate the interval query parameter in the latest ad stream endpoint and return an HTTP 400 for invalid values
- add a regression test ensuring the endpoint rejects non-numeric interval inputs

## Testing
- pytest tests/test_latest_stream.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf2999cc88322a2480ee0fd45d5ca