### PR TITLE
Add Vertex AI ad generation endpoint

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,8 @@ Flask>=2.3
 numpy>=1.24
 Pillow>=9.5
 google-generativeai>=0.5.0
+# Vertex AI SDK（Gemini + Imagen）
 google-cloud-aiplatform>=1.63.0
+# GCS 用於儲存生成的廣告海報
 google-cloud-storage>=2.17.0
 boto3>=1.28


### PR DESCRIPTION
## Summary
- add a dedicated `/adgen` endpoint that uses Gemini 2.5 Pro and Imagen to create ad copy and 1080x1080 creatives with timing logs
- strengthen `/healthz` by validating write access to the ads directory and exposing GCS connection status details
- document the Vertex AI flow, probability formulas, environment variables, and fallback behaviour in the README while noting new dependencies

## Testing
- `pytest -q`

## Environment Variables
- `GOOGLE_APPLICATION_CREDENTIALS`
- `GCP_PROJECT_ID`
- `GCP_REGION`
- `ASSET_BUCKET`
- `VERTEX_TEXT_MODEL` (optional)
- `VERTEX_IMAGE_MODEL` (optional)
- `VERTEX_IMAGE_SIZE` (optional)

## Rollback Plan
- Revert this PR and redeploy the previous application version to remove the Vertex AI ad generation endpoint and README updates.


------
https://chatgpt.com/codex/tasks/task_e_68dcfdd03f40832e8294acd487454fbf