### PR TITLE
Integrate purchase predictions into dashboard

### DIFF
--- a/backend/advertising.py
+++ b/backend/advertising.py
@@ -18,6 +18,11 @@ class AdContext:
     purchases: list[Purchase]
 
 
+@dataclass
+class PurchaseInsights:
+    recommended_item: str | None = None
+
+
 def build_ad_context(
     member_id: str, purchases: Iterable[Purchase], creative: AdCreative | None = None
 ) -> AdContext:

--- a/backend/catalogue.py
+++ b/backend/catalogue.py
@@ -1,0 +1,92 @@
+"""Static product catalogue used for purchase predictions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable
+
+CATEGORY_LABELS: dict[str, str] = {
+    "breakfast": "穀物 / 早餐",
+    "wellness": "健康飲品",
+    "fitness": "運動配件",
+    "beauty": "美妝保養",
+    "family": "親子生活",
+    "home": "居家用品",
+    "general": "生活選品",
+}
+
+
+@dataclass(frozen=True)
+class Product:
+    code: str
+    name: str
+    category: str
+    price: float
+    view_rate: float
+
+
+_CATALOGUE: tuple[Product, ...] = (
+    Product("SKU100234", "桂花牌有機澳洲燕麥片 500g", "breakfast", 250.0, 0.85),
+    Product("SKU204233", "Light 能量蛋白棒｜醇濃巧克力", "wellness", 260.0, 0.8),
+    Product("SKU401022", "冷壓綜合果汁 350ml", "wellness", 95.0, 0.75),
+    Product("SKU305120", "瑜伽墊止滑清潔噴霧", "fitness", 240.0, 0.72),
+    Product("SKU401023", "無糖優格 200ml", "wellness", 250.0, 0.74),
+    Product("SKU823144", "冷壓蘋果果汁 350ml", "wellness", 95.0, 0.73),
+    Product("SKU621412", "橡膠啞鈴 14kg", "fitness", 395.0, 0.68),
+    Product("SKU510001", "高纖優格脆片 400g", "breakfast", 320.0, 0.69),
+    Product("SKU612300", "薑黃能量飲 12入", "wellness", 520.0, 0.65),
+    Product("SKU720450", "深層舒緩瑜伽滾筒", "fitness", 880.0, 0.6),
+    Product("SKU830210", "莓果活力綜合果昔包", "wellness", 180.0, 0.66),
+    Product("SKU910120", "植萃保濕面膜 5 入", "beauty", 350.0, 0.58),
+    Product("SKU930450", "香氛舒眠枕頭噴霧", "home", 420.0, 0.54),
+    Product("SKU950310", "親子手作烘焙組", "family", 560.0, 0.62),
+)
+
+_CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "breakfast": ("燕麥", "脆片", "穀", "早餐"),
+    "wellness": ("果汁", "飲", "優格", "能量", "茶"),
+    "fitness": ("瑜伽", "啞鈴", "運動", "健身", "滾筒"),
+    "beauty": ("面膜", "保濕", "精華", "美妝"),
+    "family": ("親子", "幼兒", "家庭", "手作"),
+    "home": ("香氛", "居家", "枕頭", "噴霧"),
+}
+
+
+def category_label(category: str) -> str:
+    return CATEGORY_LABELS.get(category, CATEGORY_LABELS["general"])
+
+
+def get_catalogue() -> list[Product]:
+    return list(_CATALOGUE)
+
+
+def infer_category_from_item(item: str) -> str:
+    normalized = item.lower()
+    for product in _CATALOGUE:
+        name = product.name.lower()
+        if name in normalized or normalized in name:
+            return product.category
+    for category, keywords in _CATEGORY_KEYWORDS.items():
+        if any(keyword in normalized for keyword in keywords):
+            return category
+    return "general"
+
+
+@lru_cache(maxsize=1)
+def _normalized_lookup() -> dict[str, Product]:
+    lookup: dict[str, Product] = {}
+    for product in _CATALOGUE:
+        lookup[product.name.lower()] = product
+    return lookup
+
+
+def purchased_product_codes(items: Iterable[str]) -> set[str]:
+    lookup = _normalized_lookup()
+    codes: set[str] = set()
+    for item in items:
+        normalized = item.lower()
+        for name, product in lookup.items():
+            if name in normalized or normalized in name:
+                codes.add(product.code)
+                break
+    return codes

--- a/backend/static/style.css
+++ b/backend/static/style.css
@@ -572,6 +572,17 @@ span~#tab>div:first-of-type,
 .tab-content-1 table td:nth-child(2) {
     text-align: left
 }
+
+.prediction-results {
+    position: relative;
+    padding-top: 12px;
+}
+
+.prediction-window-label {
+    margin: 0 0 12px 0;
+    color: #6d6d6d;
+    font-size: 0.95em;
+}
 .purchase-history th.datetime,
 .purchase-history th.item,
 .purchase-history th.category,

--- a/backend/templates/dashboard.html
+++ b/backend/templates/dashboard.html
@@ -107,92 +107,50 @@
                                 <li><a href="" class="search">搜尋</a></li>
                                 <li><a href="" class="filter">篩選</a></li>
                             </ul>
-                            <table>
-                                <thead>
-                                    <tr>
-                                        <th>內部商品編號</th>
-                                        <th>商品名稱</th>
-                                        <th>商品類別</th>
-                                        <th>商品價格</th>
-                                        <th>商品<br/>查閱率</th>
-                                        <!--th>廣告<br/>查閱率</th>
-                                        <th>相似紀錄<br/>符合率</th-->
-                                        <th>預估購買機率</th>
-                                    </tr>
-                                </thead>
-                            <tbody>
-                                <tr>
-                                    <td>100234</td>
-                                    <td>桂花牌有機澳洲燕麥片 500g</td>
-                                    <td>穀物 / 早餐</td>
-                                    <td>$250</td>
-                                    <td>85%</td>
-                                    <!--td>70%</td>
-                                    <td>90%</td-->
-                                    <td><span class="hight">96%</span></td>
-                                </tr>
-                                <tr>
-                                    <td>204233</td>
-                                    <td>Light 能量蛋白棒 | 醇濃巧克力</td>
-                                    <td>健康飲品</td>
-                                    <td>$260</td>
-                                    <td>80%</td>
-                                    <!--td>65%</td>
-                                    <td>85%</td-->
-                                    <td><span class="hight">92%</span></td>
-                                </tr>
-                                <tr>
-                                    <td>401022</td>
-                                    <td>冷壓綜合果汁 350ml</td>
-                                    <td>健康飲品</td>
-                                    <td>$95</td>
-                                    <td>75%</td>
-                                    <!--td>60%</td>
-                                    <td>80%</td-->
-                                    <td><span class="hight">80%</span></td>
-                                </tr>
-                                <tr>
-                                    <td>305120</td>
-                                    <td>瑜伽墊止滑清潔噴霧</td>
-                                    <td>運動配件</td>
-                                    <td>$240</td>
-                                    <td>75%</td>
-                                    <!--td>60%</td>
-                                    <td>40%</td-->
-                                    <td><span class="medium">70%</span></td>
-                                </tr>
-                                <tr>
-                                    <td>401022</td>
-                                    <td>無糖優格 200ml</td>
-                                    <td>健康飲品</td>
-                                    <td>$$250</td>
-                                    <td>75%</td>
-                                    <!--td>45%</td>
-                                    <td>31%</td-->
-                                    <td><span class="medium">68%</span></td>
-                                </tr>
-                                <tr>
-                                    <td>823144</td>
-                                    <td>冷壓蘋果果汁 350ml</td>
-                                    <td>健康飲品</td>
-                                    <td>$95</td>
-                                    <td>75%</td>
-                                    <!--td>39%</td>
-                                    <td>26%</td-->
-                                    <td><span class="medium">67%</span></td>
-                                </tr>
-                                <tr>
-                                    <td>621412</td>
-                                    <td>橡膠啞鈴 14kg</td>
-                                    <td>運動配件</td>
-                                    <td>$395</td>
-                                    <td>72%</td>
-                                    <!--td>25%</td>
-                                    <td>21%</td-->
-                                    <td><span class="medium">66%</span></td>
-                                </tr>
-                            </tbody>
-                        </table>
+                            <section class="prediction-results">
+                                {% if prediction_window_label %}
+                                <p class="prediction-window-label" id="prediction-window-label">參考期間：{{ prediction_window_label }}</p>
+                                {% endif %}
+                                <table aria-describedby="prediction-window-label">
+                                    <thead>
+                                        <tr>
+                                            <th>商品編號</th>
+                                            <th>商品名稱</th>
+                                            <th>商品類別</th>
+                                            <th>商品價格</th>
+                                            <th>查閱率</th>
+                                            <th>預估購買機率</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="prediction-table-body">
+                                        {% if predicted_items %}
+                                            {% for item in predicted_items %}
+                                                {% set probability_class = 'hight' if item.probability_percent >= 85 else 'medium' if item.probability_percent >= 60 else '' %}
+                                                {% set probability_text = '%.1f'|format(item.probability_percent) %}
+                                                <tr data-prediction-row="true" data-index="{{ loop.index0 }}">
+                                                    <td>{{ item.product_code }}</td>
+                                                    <td>{{ item.product_name }}</td>
+                                                    <td>{{ item.category_label }}</td>
+                                                    <td>{{ '${:,.0f}'.format(item.price) }}</td>
+                                                    <td>{{ '%.1f'|format(item.view_rate_percent) }}%</td>
+                                                    <td>
+                                                        {% if probability_class %}
+                                                            <span class="{{ probability_class }}">{{ probability_text }}%</span>
+                                                        {% else %}
+                                                            {{ probability_text }}%
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        {% else %}
+                                            <tr class="empty-message" data-empty-row="true">
+                                                <td colspan="6">目前無可用的推薦商品。</td>
+                                            </tr>
+                                        {% endif %}
+                                    </tbody>
+                                </table>
+                                <ul class="page" id="prediction-pagination" aria-label="感興趣商品推估頁面導覽"></ul>
+                            </section>
                         <div class="advertising">
                             <ul class="advertising_info">
                                 <!-- <li><span>上傳速度</span>0.3秒</li>
@@ -205,11 +163,6 @@
                                 </li>
                             </ul>
                         </div>
-                        <ul class="page">
-                            <li class="active"><a href="" title="第1頁">1</a></li>
-                            <li><a href="" title="第2頁">2</a></li>
-                            <li><a href="" title="第3頁">3</a></li>
-                        </ul>
                     </div>
                     <div class="tab-content-2">
                         <h3 class="hide">歷史消費紀錄</h3>
@@ -274,5 +227,68 @@
     <!-- <footer>
         <p>2025 &copy;  你的專屬折扣
     </footer> -->
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const tableBody = document.querySelector('#prediction-table-body');
+        const pagination = document.querySelector('#prediction-pagination');
+        if (!tableBody || !pagination) {
+            return;
+        }
+
+        const dataRows = Array.from(tableBody.querySelectorAll('tr[data-prediction-row="true"]'));
+        if (!dataRows.length) {
+            pagination.style.display = 'none';
+            return;
+        }
+
+        const pageSize = 7;
+        const totalPages = Math.ceil(dataRows.length / pageSize);
+        let currentPage = 1;
+
+        function renderPage(page) {
+            currentPage = page;
+            dataRows.forEach(function (row, index) {
+                const pageIndex = Math.floor(index / pageSize) + 1;
+                row.style.display = pageIndex === page ? '' : 'none';
+            });
+            const items = pagination.querySelectorAll('li');
+            items.forEach(function (item, index) {
+                item.classList.toggle('active', index + 1 === page);
+            });
+        }
+
+        function buildPagination() {
+            pagination.innerHTML = '';
+            if (totalPages <= 1) {
+                pagination.style.display = 'none';
+                return;
+            }
+
+            pagination.style.display = '';
+            for (let page = 1; page <= totalPages; page += 1) {
+                const li = document.createElement('li');
+                if (page === currentPage) {
+                    li.classList.add('active');
+                }
+                const link = document.createElement('a');
+                link.href = '#';
+                link.textContent = String(page);
+                link.title = `第${page}頁`;
+                link.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    if (page === currentPage) {
+                        return;
+                    }
+                    renderPage(page);
+                });
+                li.appendChild(link);
+                pagination.appendChild(li);
+            }
+        }
+
+        buildPagination();
+        renderPage(1);
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- call the prediction helper from the dashboard route and expose the suggested items to the template
- render the interest table with prediction results and add client-side paging for seven rows per page
- add styling for the new prediction section on the dashboard

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68dd45e1bcc08322acac36b6b0560b4d