### PR TITLE
Define default ads directory

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,38 +4,41 @@ from __future__ import annotations
 
 import json
 import logging
-
-from datetime import datetime
-
-import json
 import math
 import mimetypes
+import os
+from datetime import datetime
 from io import BytesIO
-
 from pathlib import Path
+from queue import Queue
+from threading import Lock
 from time import perf_counter
 from typing import Iterable, Tuple
 from uuid import uuid4
 
-from queue import Queue
-from threading import Lock
-
 from flask import (
     Flask,
     Response,
+    abort,
+    current_app,
     jsonify,
     render_template,
     request,
-    Response,
     send_from_directory,
     stream_with_context,
     url_for,
 )
-
-
+from google.cloud import storage
 from PIL import Image, ImageOps, UnidentifiedImageError
+from werkzeug.utils import safe_join
 
-from .advertising import AdContext, build_ad_context
+from .advertising import (
+    AD_IMAGE_BY_SCENARIO,
+    AdContext,
+    analyse_purchase_intent,
+    build_ad_context,
+    derive_scenario_key,
+)
 from .ai import GeminiService, GeminiUnavailableError
 from .aws import RekognitionService
 from .database import Database, Purchase, SEED_MEMBER_IDS
@@ -61,6 +64,8 @@ DATA_DIR = BASE_DIR / "data"
 DB_PATH = Path(os.environ.get("DB_PATH", str(DATA_DIR / "mvp.sqlite3")))
 UPLOAD_DIR = Path(os.environ.get("UPLOAD_DIR", str(DATA_DIR / "uploads")))
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+ADS_DIR = Path(os.environ.get("ADS_DIR", str(DATA_DIR / "ads")))
+ADS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 PERSONA_LABELS = {
@@ -73,7 +78,7 @@ PERSONA_LABELS = {
 
 app = Flask(__name__, template_folder=str(BASE_DIR / "templates"))
 app.config["JSON_AS_ASCII"] = False
-app.config["ADS_DIR"] = ADS_DIR  # 儲存為字串路徑
+app.config["ADS_DIR"] = str(ADS_DIR)  # 儲存為字串路徑
 app.register_blueprint(adgen_blueprint)
 
 # -----------------------------------------------------------------------------
@@ -503,80 +508,6 @@ def render_ad(member_id: str):
         hero_image_url=hero_image_url,
         scenario_key=context.scenario_key,
     )
-
-
-@app.get("/ad/latest/stream")
-def latest_ad_stream() -> Response:
-    """Server-Sent Events feed with the most recent personalised ad metadata."""
-
-    interval_arg = request.args.get("interval", "2.0")
-    try:
-        poll_interval = float(interval_arg)
-    except (TypeError, ValueError):
-        return jsonify({"error": "Invalid interval"}), 400
-
-    poll_interval = max(0.5, min(10.0, poll_interval))
-    send_once = request.args.get("once", "0") == "1"
-    last_event_id = request.headers.get("Last-Event-ID") or request.args.get("lastEventId")
-
-    def _event_payload(event) -> tuple[dict[str, object], str]:
-        if event is None:
-            return {
-                "status": "idle",
-                "message": "No uploads have been recorded yet.",
-            }, "0"
-
-        ad_url = url_for("render_ad", member_id=event.member_id, _external=True)
-        image_url = (
-            url_for("serve_upload_image", filename=event.image_filename, _external=True)
-            if event.image_filename
-            else None
-        )
-
-        payload = {
-            "status": "ok",
-            "event_id": event.id,
-            "created_at": event.created_at,
-            "member_id": event.member_id,
-            "member_code": event.member_code,
-            "ad_url": ad_url,
-        }
-        if image_url:
-            payload["image_url"] = image_url
-        return payload, str(event.id)
-
-    def _format_sse(event_id: str, payload: dict[str, object]) -> str:
-        data = json.dumps(payload, ensure_ascii=False)
-        return f"id: {event_id}\nevent: latest-ad\ndata: {data}\n\n"
-
-    @stream_with_context
-    def _generate():
-        last_sent_id = last_event_id or ""
-
-        while True:
-            event = database.get_latest_upload_event()
-            payload, event_id = _event_payload(event)
-
-            if not send_once and last_sent_id == event_id and event is not None:
-                time.sleep(poll_interval)
-                continue
-
-            chunk = _format_sse(event_id, payload)
-            yield chunk
-            last_sent_id = event_id
-
-            if send_once:
-                break
-
-            time.sleep(poll_interval)
-
-    headers = {
-        "Cache-Control": "no-cache",
-        "Content-Type": "text/event-stream; charset=utf-8",
-        "X-Accel-Buffering": "no",
-    }
-    return Response(_generate(), headers=headers)
-
 
 
 @app.get("/ad/latest")


### PR DESCRIPTION
## Summary
- define a default ads asset directory from configuration or fallback path
- ensure the ads directory exists on startup and store its string path in Flask config
- remove the duplicate /ad/latest/stream registration so the SSE endpoint is only defined once

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd0a8d67083228c44c0ab8bf0bd02