### PR TITLE
Define REKOG_RESET config from environment

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import mimetypes
+import os
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -65,6 +66,8 @@ UPLOAD_DIR = Path(os.environ.get("UPLOAD_DIR", str(DATA_DIR / "uploads")))
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 ADS_DIR = Path(os.environ.get("ADS_DIR", str(DATA_DIR / "ads")))
 ADS_DIR.mkdir(parents=True, exist_ok=True)
+
+REKOG_RESET = os.environ.get("REKOG_RESET", "").strip().lower() in {"1", "true", "yes"}
 
 
 PERSONA_LABELS = {


### PR DESCRIPTION
## Summary
- import the os module for backend configuration
- define the REKOG_RESET boolean from the environment so Rekognition startup logic has a defined flag

## Testing
- python -c "import backend.app"

------
https://chatgpt.com/codex/tasks/task_e_68dde536f15083228e7f5716627d54d7