### PR TITLE
Prefer reserved member IDs when registering faces

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -470,11 +470,7 @@ class Database:
                 WHERE member_id = ?
                   AND member_id IS NOT NULL
                   AND TRIM(member_id) <> ''
-                  AND NOT EXISTS (
-                        SELECT 1
-                        FROM upload_events
-                        WHERE upload_events.member_id = member_profiles.member_id
-                    )
+                  AND first_image_filename IS NULL
                 LIMIT 1
                 """,
                 (preferred_member_id,),
@@ -488,11 +484,7 @@ class Database:
             FROM member_profiles
             WHERE member_id IS NOT NULL
               AND TRIM(member_id) <> ''
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM upload_events
-                    WHERE upload_events.member_id = member_profiles.member_id
-                )
+              AND first_image_filename IS NULL
             ORDER BY profile_id
             """,
         ).fetchall()


### PR DESCRIPTION
## Summary
- introduce a helper to locate pre-assigned member profiles with no upload history
- update `create_member` to reuse reserved member IDs instead of generating random identifiers
- skip the automatic profile claiming step when a reserved ID is claimed and seed its purchase history

## Testing
- python -m compileall backend
- pytest tests/test_latest_stream.py -k latest --maxfail=1 *(hangs on existing SSE stream test; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68dead91a0dc8322b0dcad235d8d023c