### PR TITLE
Add Gemini ad composition API, CLI, and preview page

### DIFF
--- a/ads-preview.html
+++ b/ads-preview.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8" />
+  <title>ESP32 CAM 廣告合成測試</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body {
+      font-family: "Noto Sans TC", "Helvetica Neue", Arial, sans-serif;
+      background: #10141c;
+      color: #f4f6fb;
+      margin: 0;
+      padding: 2rem;
+    }
+    h1 {
+      margin-top: 0;
+      font-size: 2rem;
+    }
+    .card {
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+    }
+    button {
+      background: linear-gradient(135deg, #ff9a4b, #ff4d4d);
+      color: #fff;
+      border: none;
+      border-radius: 999px;
+      padding: 0.6rem 1.6rem;
+      font-size: 1rem;
+      cursor: pointer;
+      margin-right: 0.5rem;
+      margin-bottom: 0.5rem;
+      transition: transform 0.2s ease;
+    }
+    button:hover {
+      transform: translateY(-2px);
+    }
+    pre {
+      background: rgba(0, 0, 0, 0.45);
+      border-radius: 12px;
+      padding: 1rem;
+      overflow-x: auto;
+      max-height: 400px;
+    }
+    a {
+      color: #7ec8ff;
+    }
+    .status {
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      color: #ffd166;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>ESP32 CAM 廣告合成測試入口</h1>
+    <p>
+      點選以下按鈕即可呼叫 <code>/ad/&lt;member_id&gt;/compose</code> API，
+      並在下方檢視回傳 JSON 結果。
+    </p>
+    <div>
+      <button data-member="ME0001">生成 ME0001（甜點）</button>
+      <button data-member="ME0002">生成 ME0002（幼兒園）</button>
+      <button data-member="ME0003">生成 ME0003（健身房）</button>
+    </div>
+    <p class="status" id="status">尚未呼叫 API。</p>
+  </div>
+
+  <div class="card">
+    <h2>回傳結果</h2>
+    <pre id="result">{ }
+</pre>
+  </div>
+
+  <div class="card">
+    <h2>快速驗收步驟</h2>
+    <ol>
+      <li>啟動後端伺服器，確認 <code>http://127.0.0.1:8000</code> 可連線。</li>
+      <li>分別執行：<code>curl -fsS "http://127.0.0.1:8000/ad/ME0001/compose" | jq .</code> 等指令。</li>
+      <li>確認 <code>/srv/esp32-ads/out</code> 內產生對應 JPG。</li>
+    </ol>
+    <p>
+      若要重新產生素材，可在 API 加上 <code>?force=1</code> 或使用 CLI：
+      <code>python -m backend.tools.generate_ad --member ME0001 --force</code>
+    </p>
+  </div>
+
+  <script>
+    const buttons = document.querySelectorAll('button[data-member]');
+    const resultEl = document.getElementById('result');
+    const statusEl = document.getElementById('status');
+
+    async function callApi(memberId) {
+      const url = `http://127.0.0.1:8000/ad/${memberId}/compose`;
+      statusEl.textContent = `呼叫 ${url} 中...`;
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text || response.statusText);
+        }
+        const data = await response.json();
+        resultEl.textContent = JSON.stringify(data, null, 2);
+        statusEl.textContent = `已取得 ${memberId} 的廣告資料，輸出檔案：${data.out_path || '未知'}`;
+      } catch (error) {
+        console.error(error);
+        statusEl.textContent = `呼叫失敗：${error.message}`;
+      }
+    }
+
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const memberId = btn.dataset.member;
+        callApi(memberId);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/backend/ad_pipeline.py
+++ b/backend/ad_pipeline.py
@@ -1,0 +1,144 @@
+"""High level helper to compose personalised advertisements with caching."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Dict
+
+from .advertising import (
+    AdCopy,
+    compose_final_image,
+    generate_ad_copy_via_gemini,
+    get_member_scenario,
+    member_to_base_image,
+)
+from .prediction import predict_for_member, recent_summary
+
+
+_CACHE_FILENAME = "index.json"
+_CACHE_TTL = timedelta(minutes=10)
+
+
+def _out_dir() -> Path:
+    configured = os.environ.get("AD_OUT_DIR")
+    if configured:
+        path = Path(configured)
+    else:
+        base_dir = Path(os.environ.get("AD_BASE_DIR", "/srv/esp32-ads"))
+        path = base_dir / "out"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _index_path(out_dir: Path) -> Path:
+    return out_dir / _CACHE_FILENAME
+
+
+def _load_cache(path: Path) -> Dict[str, Dict[str, Any]]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data  # type: ignore[return-value]
+
+
+def _save_cache(path: Path, payload: Dict[str, Dict[str, Any]]) -> None:
+    tmp_path = path.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    tmp_path.replace(path)
+
+
+def _is_fresh(entry: Dict[str, Any]) -> bool:
+    timestamp = entry.get("generated_at")
+    if not timestamp:
+        return False
+    try:
+        generated = datetime.fromisoformat(str(timestamp))
+    except ValueError:
+        return False
+    if generated.tzinfo is None:
+        generated = generated.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    return now - generated <= _CACHE_TTL
+
+
+def _ensure_member_filename(path_str: str, member_id: str) -> str:
+    path = Path(path_str)
+    expected_prefix = f"{member_id}_"
+    if path.name.startswith(expected_prefix):
+        return str(path)
+    new_path = path.with_name(expected_prefix + path.name)
+    try:
+        path.rename(new_path)
+    except OSError:
+        return str(path)
+    return str(new_path)
+
+
+def compose_member_ad(
+    member_id: str,
+    *,
+    force: bool = False,
+    limit: int = 3,
+    svc=None,
+) -> Dict[str, Any]:
+    """Generate or return cached advertisement payload for the given member."""
+
+    out_dir = _out_dir()
+    cache_path = _index_path(out_dir)
+    cache = _load_cache(cache_path)
+    cache_entry = cache.get(member_id)
+    if cache_entry and not force and _is_fresh(cache_entry):
+        cached_payload = cache_entry.get("data")
+        if isinstance(cached_payload, dict):
+            return cached_payload
+
+    scenario_key, scenario_label = get_member_scenario(member_id)
+    base_image = member_to_base_image(member_id)
+
+    top_predictions = predict_for_member(member_id, limit=limit)
+    summary = recent_summary(member_id)
+
+    gemini_start = perf_counter()
+    copy: AdCopy = generate_ad_copy_via_gemini(
+        member_id,
+        scenario_label,
+        top_predictions,
+        summary,
+        svc=svc,
+    )
+    gemini_duration = int((perf_counter() - gemini_start) * 1000)
+
+    compose_start = perf_counter()
+    output_path = compose_final_image(base_image, copy, out_dir=str(out_dir))
+    output_path = _ensure_member_filename(output_path, member_id)
+    compose_duration = int((perf_counter() - compose_start) * 1000)
+
+    payload: Dict[str, Any] = {
+        "member_id": member_id,
+        "scenario": scenario_label,
+        "scenario_key": scenario_key,
+        "out_path": output_path,
+        "copy": asdict(copy),
+        "top_predictions": top_predictions,
+        "timings": {"gemini_ms": gemini_duration, "compose_ms": compose_duration},
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    cache[member_id] = {"generated_at": payload["generated_at"], "data": payload}
+    try:
+        _save_cache(cache_path, cache)
+    except OSError:
+        pass
+
+    return payload

--- a/backend/advertising.py
+++ b/backend/advertising.py
@@ -1,11 +1,19 @@
 """Business logic to transform database rows into advertising copy."""
 from __future__ import annotations
 
+import json
+import logging
+import os
+import time
 from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Iterable, Literal
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Literal, Optional
 
-from .ai import AdCreative
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+from .ai import AdCreative, GeminiService, GeminiUnavailableError
 from .database import MemberProfile, Purchase
 
 # Persona → 商品/情境「細分鍵」對應
@@ -38,6 +46,37 @@ AD_IMAGE_BY_SCENARIO: dict[str, str] = {
     "unregistered:fitness": "AD0000.jpg",
     "unregistered:homemaker": "AD0001.jpg",
 }
+
+@dataclass
+class AdCopy:
+    title: str
+    subtitle: str
+    bullets: List[str]
+
+
+FALLBACK_COPY = AdCopy(
+    title="限時優惠",
+    subtitle="會員專屬禮遇",
+    bullets=["今日下單再享驚喜"],
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+SCENARIO_ASSETS: dict[str, dict[str, str]] = {
+    "ME0001": {"scenario": "dessert", "label": "甜點", "image": "ME0001.jpg"},
+    "ME0002": {"scenario": "kindergarten", "label": "幼兒園", "image": "ME0002.jpg"},
+    "ME0003": {"scenario": "fitness", "label": "健身房", "image": "ME0003.jpg"},
+}
+
+
+def _resolve_asset_config(member_id: str) -> dict[str, str]:
+    key = member_id[:6]
+    if key in SCENARIO_ASSETS:
+        return SCENARIO_ASSETS[key]
+    raise KeyError(f"No scenario asset mapping for member_id={member_id}")
+
 
 @dataclass
 class PurchaseInsights:
@@ -251,3 +290,242 @@ def _subheading_prefix(member_code: str) -> str:
     if member_code:
         return f"商場會員代號：{member_code}｜"
     return "尚未綁定商場會員，立即至服務台完成綁定享專屬禮遇｜"
+
+
+def get_member_scenario(member_id: str) -> tuple[str, str]:
+    """Return (scenario_key, scenario_label) for the provided member ID."""
+
+    try:
+        config = _resolve_asset_config(member_id)
+    except KeyError as exc:  # pragma: no cover - defensive guard for future IDs
+        raise FileNotFoundError(f"Unable to resolve scenario for {member_id}") from exc
+    return config["scenario"], config["label"]
+
+
+def member_to_base_image(member_id: str) -> str:
+    """依 member_id 決定底圖路徑"""
+
+    base_dir = Path(os.environ.get("AD_BASE_DIR", "/srv/esp32-ads"))
+    config = _resolve_asset_config(member_id)
+    image_path = base_dir / config["image"]
+    return str(image_path)
+
+
+def _default_font_path() -> str:
+    return os.environ.get(
+        "FONT_PATH", "/usr/share/fonts/truetype/noto/NotoSansTC-Regular.otf"
+    )
+
+
+def _load_font(font_path: Optional[str], size: int) -> ImageFont.FreeTypeFont:
+    tried: list[str] = []
+    candidates = [font_path, _default_font_path(), "/usr/share/fonts/truetype/noto/NotoSansTC-Bold.otf"]
+    fallback = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate)
+        if not path.exists():
+            tried.append(str(path))
+            continue
+        try:
+            return ImageFont.truetype(str(path), size=size)
+        except OSError:
+            tried.append(str(path))
+            continue
+    try:
+        return ImageFont.truetype(fallback, size=size)
+    except OSError:
+        _LOGGER.warning("Unable to load preferred fonts (%s); falling back to default.", ", ".join(tried))
+        return ImageFont.load_default()
+
+
+def _normalise_bullets(values: Iterable[str]) -> list[str]:
+    bullets: list[str] = []
+    for value in values:
+        text = str(value).strip()
+        if not text:
+            continue
+        bullets.append(text)
+        if len(bullets) == 3:
+            break
+    if not bullets:
+        return FALLBACK_COPY.bullets
+    return bullets
+
+
+def _build_prompt(
+    member_id: str,
+    scenario_label: str,
+    top_predictions: list[dict[str, object]],
+    recent_summary: str,
+) -> str:
+    if top_predictions:
+        lines = []
+        for item in top_predictions:
+            name = str(item.get("item") or item.get("product_name") or "推薦商品")
+            price = item.get("price")
+            probability = item.get("probability_percent") or item.get("probability")
+            if isinstance(probability, float):
+                probability = round(probability * 100, 1)
+            if isinstance(price, (int, float)):
+                price_text = f"NT${price:,.0f}"
+            else:
+                price_text = str(price or "-")
+            lines.append(f"- {name}｜預估價格 {price_text}｜購買機率 {probability}%")
+        top_block = "\n".join(lines)
+    else:
+        top_block = "- 暫無預測商品，請聚焦會員開卡禮"
+
+    prompt = (
+        "你是零售行銷文案專家。請根據「會員輪廓與預估商品」產生 1 組廣告文案：\n"
+        f"- 語氣：溫暖、直接，貼合{scenario_label}場景。\n"
+        "- 產出 JSON 物件，鍵包含：title, subtitle, bullets（陣列，長度 1~3，單行不超過 20 個全形字）。\n\n"
+        "【會員資訊】\n"
+        f"- 會員ID：{member_id}\n"
+        f"- 情境：{scenario_label}\n"
+        f"- 過去購買摘要：{recent_summary}\n\n"
+        "【預估推薦 TopN】\n"
+        f"{top_block}\n\n"
+        "請只輸出 JSON，勿加說明文字。"
+    )
+    return prompt
+
+
+def _parse_ad_copy_payload(text: str) -> AdCopy:
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.splitlines()
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        cleaned = "\n".join(lines).strip()
+    try:
+        payload = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise GeminiUnavailableError(f"Gemini 回傳格式錯誤：{exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise GeminiUnavailableError("Gemini 回傳內容不是 JSON 物件")
+
+    title = str(payload.get("title") or "").strip()
+    subtitle = str(payload.get("subtitle") or "").strip()
+    bullets_raw = payload.get("bullets")
+    if isinstance(bullets_raw, str):
+        bullets = _normalise_bullets([bullets_raw])
+    elif isinstance(bullets_raw, Iterable):
+        bullets = _normalise_bullets(bullets_raw)
+    else:
+        bullets = FALLBACK_COPY.bullets
+
+    if not title:
+        title = FALLBACK_COPY.title
+    if not subtitle:
+        subtitle = FALLBACK_COPY.subtitle
+
+    return AdCopy(title=title, subtitle=subtitle, bullets=bullets)
+
+
+def _get_gemini_service() -> GeminiService:
+    text_model = os.environ.get("GEMINI_TEXT_MODEL")
+    vision_model = os.environ.get("GEMINI_VISION_MODEL")
+    return GeminiService(text_model=text_model, vision_model=vision_model)
+
+
+def generate_ad_copy_via_gemini(
+    member_id: str,
+    scenario_label: str,
+    top_predictions: list,
+    recent_summary: str,
+    svc: Optional[GeminiService] = None,
+) -> AdCopy:
+    """呼叫 Gemini 產生文案，回傳 AdCopy 結構"""
+
+    service = svc or _get_gemini_service()
+    if not getattr(service, "can_generate_ads", False):
+        _LOGGER.warning("Gemini service unavailable; using fallback copy")
+        return FALLBACK_COPY
+
+    prompt = _build_prompt(member_id, scenario_label, top_predictions, recent_summary)
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            model = getattr(service, "_text_model", None)
+            if model is None:
+                raise GeminiUnavailableError("Gemini 文字模型未初始化")
+            response = model.generate_content(
+                prompt,
+                request_options={"timeout": getattr(service, "_timeout", 20.0)},
+            )
+            text = (getattr(response, "text", None) or "").strip()
+            if not text:
+                raise GeminiUnavailableError("Gemini 回傳為空白")
+            return _parse_ad_copy_payload(text)
+        except Exception as exc:  # pylint: disable=broad-except
+            last_error = exc
+            _LOGGER.warning("Gemini generate attempt %s failed: %s", attempt + 1, exc)
+            if attempt < 2:
+                time.sleep(0.6 * (2**attempt))
+
+    _LOGGER.error("Gemini generation failed after retries: %s", last_error)
+    return FALLBACK_COPY
+
+
+def _draw_rounded_rectangle(draw: ImageDraw.ImageDraw, bbox: tuple[int, int, int, int], radius: int, fill: tuple[int, int, int, int]) -> None:
+    draw.rounded_rectangle(bbox, radius=radius, fill=fill)
+
+
+def _ensure_output_dir(out_dir: str) -> Path:
+    output = Path(out_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    return output
+
+
+def compose_final_image(
+    base_image_path: str,
+    copy: AdCopy,
+    out_dir: str = "/srv/esp32-ads/out",
+    font_path: Optional[str] = None,
+) -> str:
+    """用 Pillow 將文案合成到底圖上，回傳輸出檔路徑"""
+
+    base_path = Path(base_image_path)
+    if not base_path.exists():
+        raise FileNotFoundError(f"底圖不存在：{base_image_path}")
+
+    output_dir = _ensure_output_dir(out_dir)
+    resampling_attr = getattr(Image, "Resampling", None)
+    if resampling_attr is not None:
+        resample_filter = getattr(resampling_attr, "LANCZOS", getattr(Image, "LANCZOS", Image.BICUBIC))
+    else:
+        resample_filter = getattr(Image, "LANCZOS", Image.BICUBIC)
+
+    with Image.open(base_path) as img:
+        canvas = ImageOps.fit(img.convert("RGBA"), (1920, 1080), method=resample_filter)
+
+    overlay = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+    overlay_draw = ImageDraw.Draw(overlay)
+    background_alpha = int(255 * 0.4)
+    _draw_rounded_rectangle(overlay_draw, (80, 80, 1840, 360), 36, (0, 0, 0, background_alpha))
+    _draw_rounded_rectangle(overlay_draw, (80, 300, 1840, 500), 30, (0, 0, 0, background_alpha))
+    _draw_rounded_rectangle(overlay_draw, (80, 480, 1840, 820), 30, (0, 0, 0, background_alpha))
+
+    canvas = Image.alpha_composite(canvas, overlay)
+    draw = ImageDraw.Draw(canvas)
+
+    title_font = _load_font(font_path, 72)
+    subtitle_font = _load_font(font_path, 44)
+    bullet_font = _load_font(font_path, 40)
+
+    draw.text((100, 120), copy.title, font=title_font, fill=(255, 255, 255), stroke_width=2, stroke_fill=(0, 0, 0))
+    draw.text((100, 330), copy.subtitle, font=subtitle_font, fill=(255, 255, 255), stroke_width=2, stroke_fill=(0, 0, 0))
+
+    bullets = _normalise_bullets(copy.bullets)
+    for index, bullet in enumerate(bullets):
+        y = 520 + index * 64
+        draw.text((100, y), f"• {bullet}", font=bullet_font, fill=(255, 255, 255), stroke_width=2, stroke_fill=(0, 0, 0))
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    member_id = Path(base_image_path).stem.split("_")[0]
+    filename = f"{member_id}_{timestamp}.jpg"
+    out_path = output_dir / filename
+    canvas.convert("RGB").save(out_path, format="JPEG", quality=92)
+    return str(out_path)

--- a/backend/app.py
+++ b/backend/app.py
@@ -45,7 +45,7 @@ from .database import Database, Purchase, SEED_MEMBER_IDS
 
 from .prediction import predict_next_purchases
 from .recognizer import FaceRecognizer
-from .routes import adgen_blueprint
+from .routes import adgen_blueprint, ads_blueprint
 
 # -----------------------------------------------------------------------------
 # Logging
@@ -82,6 +82,7 @@ app = Flask(__name__, template_folder=str(BASE_DIR / "templates"))
 app.config["JSON_AS_ASCII"] = False
 app.config["ADS_DIR"] = str(ADS_DIR)  # 儲存為字串路徑
 app.register_blueprint(adgen_blueprint)
+app.register_blueprint(ads_blueprint)
 
 # -----------------------------------------------------------------------------
 # Services (Vertex AI / AWS Rekognition / DB)

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,5 +1,6 @@
 """Route blueprints for the ESP32-CAM backend."""
 
 from .adgen import adgen_blueprint
+from .ads import ads_blueprint
 
-__all__ = ["adgen_blueprint"]
+__all__ = ["adgen_blueprint", "ads_blueprint"]

--- a/backend/routes/ads.py
+++ b/backend/routes/ads.py
@@ -1,0 +1,23 @@
+"""HTTP routes for composing and caching advertisement creatives."""
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify, request
+
+from ..ad_pipeline import compose_member_ad
+
+
+ads_blueprint = Blueprint("ads", __name__)
+
+
+@ads_blueprint.get("/ad/<member_id>/compose")
+def compose_ad_endpoint(member_id: str):
+    force_flag = str(request.args.get("force", "0")).lower() in {"1", "true", "yes"}
+    try:
+        payload = compose_member_ad(member_id, force=force_flag)
+    except FileNotFoundError:
+        return jsonify({"error": "底圖不存在或未配置"}), 404
+    except Exception as exc:  # pylint: disable=broad-except
+        current_app.logger.exception("Failed to compose advertisement for %s", member_id)
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify(payload)

--- a/backend/tools/generate_ad.py
+++ b/backend/tools/generate_ad.py
@@ -1,0 +1,35 @@
+"""CLI tool to generate and cache personalised advertisements."""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from ..ad_pipeline import compose_member_ad
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate advertisement for a member")
+    parser.add_argument("--member", required=True, help="Member ID (e.g. ME0001)")
+    parser.add_argument("--limit", type=int, default=3, help="Number of top predictions to include")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force regeneration instead of using cached result",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    payload: dict[str, Any] = compose_member_ad(
+        args.member,
+        limit=args.limit,
+        force=bool(args.force),
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    print(payload.get("out_path", ""))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- build a Gemini-backed advertising copy helper that assembles creatives on cached backgrounds
- expose a GET /ad/<member_id>/compose endpoint and matching CLI utility for forcing regeneration
- add an HTML helper page for manually exercising the compose API

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68df2da43148832eba9f83305932d878