### PR TITLE
Normalize placeholder profiles for unknown visitors

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -76,6 +76,7 @@ PERSONA_LABELS = {
     "fitness-enthusiast": "健身族",
     "home-manager": "家庭主婦",
     "wellness-gourmet": "健康食品愛好者",
+    "unknown": "未註冊客戶",
 }
 
 app = Flask(__name__, template_folder=str(BASE_DIR / "templates"))

--- a/backend/data/mvp.sql
+++ b/backend/data/mvp.sql
@@ -1,7 +1,7 @@
 BEGIN TRANSACTION;
 CREATE TABLE member_profiles (
                     profile_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    profile_label TEXT NOT NULL UNIQUE,
+                    profile_label TEXT NOT NULL,
                     name TEXT,
                     member_id TEXT UNIQUE,
                     mall_member_id TEXT,


### PR DESCRIPTION
## Summary
- remove the UNIQUE constraint on `member_profiles.profile_label` and migrate existing databases to the relaxed schema
- normalize pre-seeded placeholder rows to use the `unknown` persona label and ensure a small pool of anonymous profiles exists
- expose the `unknown` persona display label so the UI shows a friendly name

## Testing
- python -m compileall backend
- pytest -k latest_stream -vv *(hangs on existing SSE test; interrupted manually)*

------
https://chatgpt.com/codex/tasks/task_e_68e28eaa73d08322b453023ec8dd6005