### PR TITLE
Fix missing parenthesis in database seeding

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1422,6 +1422,7 @@ class Database:
             email=None,
             address=None,
             occupation=None,
+        )
 
 
         with self._connect() as conn:


### PR DESCRIPTION
## Summary
- close the `_seed_member_profile` call for the `wellness-gourmet` seed data with the missing parenthesis
- ensure the surrounding `Database.__init__` block now parses correctly

## Testing
- python -m compileall backend/database.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d37f9c7083228ab1200f9b8f92c0